### PR TITLE
DEV-13718 [라미엘] 세션 잠금 상태 메시지에 user-agent 표시

### DIFF
--- a/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
+++ b/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
@@ -81,7 +81,7 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
         //
     }
 
-    // TODO: HBsmith DEV-12387, DEV-12826, DEV-13214, DEV-13549
+    // TODO: HBsmith DEV-12387, DEV-12826, DEV-13214, DEV-13549, DEV-13718
     private static async apiCreateSession(ws: WS, udid: string, userAgent?: string) {
         const host = Config.getInstance().getRamielApiServerEndpoint();
         const api = `/real-devices/${udid}/control/`;
@@ -116,8 +116,10 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
                 );
                 let msg = `[${this.TAG}] failed to create a session for ${udid}`;
                 if (!('response' in error)) msg = msg = `undefined response in error`;
-                else if (409 == error.response.status) msg = `사용 중인 장비입니다`;
-                else if (503 == error.response.status) msg = `장비의 연결이 끊어져있습니다`;
+                else if (409 == error.response.status) {
+                    msg = `사용 중인 장비입니다`;
+                    if (userAgent) msg += ` (${userAgent})`;
+                } else if (503 == error.response.status) msg = `장비의 연결이 끊어져있습니다`;
                 ws.close(4900, msg);
                 throw error;
             });


### PR DESCRIPTION
### What is this PR for?

- 이미 사용중인 장비일 경우, 누가 사용중인지 표시 (userAgent)

### How should this be tested?

- vagrant up
    - master: db, sachiel, nerv, gendo, ramiel
- 리얼 디바이스를 ramiel vagrant에 연결
- nerv에서 새로 연결한 리얼디바이스에 hbsmith 팀 할당: nerv -> Real Devices -> attach ...
- ws-scrcpy 동기화
    - ramiel vagrant 접속
    - cd /opt/ramiel/ws-scrcpy
    - .git/config 수정 -> master -> *
    - `git fetch -a; git checkout DEV-13718`
    - ws-scrcpy 서비스 재시작: `launchctl stop ramiel.ws-scrcpy.hbsmith.io`
- 이미 사용중인 세션의 userAgent 확인 (naoko)
    - gendo -> naoko 실행 -> 플랫폼에서 연결한 리얼다비이스 선택 -> 녹화 시작 -> 크롬에서 장비 세션 연결까지 대기 -> 연결 후 주소복사 -> 새 탭 열어 붙여넣고 열기 -> 문구 확인 (아래 스크린샷 확인) -> 녹화 종료
- 이미 사용중인 세션의 userAgent 확인 (gendo)
    - gendo -> gendo.sln을 visual studio로 열기 -> 위 단계에서 만든 녹화본 경로 사용하여 gendo 실행 -> 크롬에서 장비 세션 연결까지 대기 -> 연결 후 주소복사 -> 새 탭 열어 붙여넣고 열기 -> 문구 확인 (아래 스크린샷 확인)

### Screenshots (if appropriate)

- 정상적인 연결
![image](https://user-images.githubusercontent.com/12525941/148313642-08304aaa-fbe9-472c-b9cc-1ba016e9ec78.png)

- 이미 사용중인 장비 (naoko)
![image](https://user-images.githubusercontent.com/12525941/148313607-f6975863-2eb7-4aba-9414-000eddcb02b8.png)

- 이미 사용중인 장비 (gendo)
![image](https://user-images.githubusercontent.com/12525941/148314247-cca4c8f3-cc3a-4d32-99ba-437f301e43d7.png)
