### PR TITLE
DEV-13561 [라미엘] 테스트 시작/끝 모든앱 강제종료

### DIFF
--- a/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
+++ b/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
@@ -243,7 +243,7 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
                 }
 
                 const cmdAppStop =
-                    'adb shell \'for pp in $(dumpsys window a | grep "/" | cut -d "{" -f2 | cut -d "/" -f1 | cut -d " " -f2); do am force-stop "${pp}"; done\'';
+                    'for pp in $(dumpsys window a | grep "/" | cut -d "{" -f2 | cut -d "/" -f1 | cut -d " " -f2); do am force-stop "${pp}"; done';
                 const cmdAppStart = `monkey -p '${this.appKey}' -c android.intent.category.LAUNCHER 1`;
 
                 device
@@ -288,7 +288,7 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
                 console.log(Utils.getTimeISOString(), output ? output : `success to run a command: ${cmdPower}`);
 
                 const cmdAppStop =
-                    'adb shell \'for pp in $(dumpsys window a | grep "/" | cut -d "{" -f2 | cut -d "/" -f1 | cut -d " " -f2); do am force-stop "${pp}"; done\'';
+                    'for pp in $(dumpsys window a | grep "/" | cut -d "{" -f2 | cut -d "/" -f1 | cut -d " " -f2); do am force-stop "${pp}"; done';
                 device
                     .runShellCommandAdbKit(cmdAppStop)
                     .then((output) => {

--- a/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
+++ b/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
@@ -189,7 +189,7 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
         return service;
     }
 
-    // TODO: HBsmith DEV-12386, DEV-13493, DEV-13549
+    // TODO: HBsmith DEV-12386, DEV-13493, DEV-13549, DEV-13561
     public release(): void {
         this.tearDownTest();
         super.release();
@@ -242,7 +242,8 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
                     return;
                 }
 
-                const cmdAppStop = `am force-stop '${this.appKey}'`;
+                const cmdAppStop =
+                    'adb shell \'for pp in $(dumpsys window a | grep "/" | cut -d "{" -f2 | cut -d "/" -f1 | cut -d " " -f2); do am force-stop "${pp}"; done\'';
                 const cmdAppStart = `monkey -p '${this.appKey}' -c android.intent.category.LAUNCHER 1`;
 
                 device
@@ -250,7 +251,7 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
                     .then((output) => {
                         console.log(
                             Utils.getTimeISOString(),
-                            output ? output : `success to stop the app: ${cmdAppStop}`,
+                            output ? output : `success to stop all of the apps: ${cmdAppStop}`,
                         );
                         return device.runShellCommandAdbKit(cmdAppStart);
                     })
@@ -286,15 +287,12 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
             .then((output) => {
                 console.log(Utils.getTimeISOString(), output ? output : `success to run a command: ${cmdPower}`);
 
-                if (!this.appKey) {
-                    return;
-                }
-
-                const cmdStopApp = `am force-stop '${this.appKey}'`;
+                const cmdAppStop =
+                    'adb shell \'for pp in $(dumpsys window a | grep "/" | cut -d "{" -f2 | cut -d "/" -f1 | cut -d " " -f2); do am force-stop "${pp}"; done\'';
                 device
-                    .runShellCommandAdbKit(cmdStopApp)
+                    .runShellCommandAdbKit(cmdAppStop)
                     .then((output) => {
-                        console.log(Utils.getTimeISOString(), output ? output : `success to stop app: ${cmdStopApp}`);
+                        console.log(Utils.getTimeISOString(), output ? output : `success to stop all of running apps`);
                     })
                     .catch((e) => {
                         console.error(Utils.getTimeISOString(), e);


### PR DESCRIPTION
### What is this PR for?

- 테스트 시작/끝 시점에서 모든 앱 강제종료
- 대상 앱: 화면이 있는 것들

### How should this be tested?

- vagrant up
    - master: db, sachiel, nerv, gendo, ramiel
- 리얼 디바이스를 ramiel vagrant에 연결
- nerv에서 새로 연결한 리얼디바이스에 hbsmith 팀 할당: nerv -> Real Devices -> attach ...
- ws-scrcpy 동기화
    - ramiel vagrant 접속
    - cd /opt/ramiel/ws-scrcpy
    - .git/config 수정 -> master -> *
    - `git fetch -a; git checkout DEV-13718`
    - ws-scrcpy 서비스 재시작: `launchctl stop ramiel.ws-scrcpy.hbsmith.io`
- 리얼 디바이스에서 임의의 앱을 수동으로 실행
- gendo -> naoko 실행 -> 플랫폼에 리얼 디바이스 선택 -> 앱키에 `com.lotte` (롯데 앱이 설치되어 있어야 함) -> 세션 연결
- 수동으로 실행한 앱이 종료되고, 앱키로 설정한 앱이 실행되는지 확인

### Screenshots (if appropriate)

- 참고 영상

https://user-images.githubusercontent.com/12525941/148327890-37d55776-51f2-4e82-b6c1-04e24704b642.mov



