### PR TITLE
DEV-14481 [라미엘] iOS 자동종료 기능 - 앱키 미기재 시, 안드로이드와 달리 앱 자동종료되지 않음

### DIFF
--- a/src/app/applDevice/client/WdaProxyClient.ts
+++ b/src/app/applDevice/client/WdaProxyClient.ts
@@ -185,8 +185,7 @@ export class WdaProxyClient
                 const value = prompt('텍스트를 입력해 주세요');
                 return this.requestWebDriverAgent(WDAMethod.SEND_TEXT, { text: value });
             case 'terminateApp':
-                const bundleId = prompt('앱 키를 입력해 주세요');
-                return this.requestWebDriverAgent(WDAMethod.TERMINATE_APP, { bundleId: bundleId });
+                return this.requestWebDriverAgent(WDAMethod.TERMINATE_APP);
         }
     }
     //

--- a/src/server/appl-device/services/WDARunner.ts
+++ b/src/server/appl-device/services/WDARunner.ts
@@ -154,12 +154,13 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
                 if (!value) return;
                 return driver.keys(value);
             case WDAMethod.TERMINATE_APP:
-                const bundleId = args.bundleId;
-                if (!bundleId) return;
-                return driver.isAppInstalled(bundleId).then(() => {
+                return driver.mobileGetActiveAppInfo().then((appInfo) => {
+                    const bundleId = appInfo['bundleId'];
+                    if (bundleId === 'com.apple.springboard') {
+                        return true;
+                    }
                     return driver.terminateApp(bundleId);
                 });
-            //
             default:
                 return `Unknown command: ${method}`;
         }

--- a/src/server/appl-device/services/WDARunner.ts
+++ b/src/server/appl-device/services/WDARunner.ts
@@ -278,6 +278,12 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
         await this.server.driver.mobilePressButton({ name: 'home' });
         await this.server.driver.mobilePressButton({ name: 'home' });
 
+        const appInfo = await this.server.driver.mobileGetActiveAppInfo();
+        const bundleId = appInfo['bundleId'];
+        if (bundleId !== 'com.apple.springboard') {
+            await this.server.driver.terminateApp(bundleId);
+        }
+
         if (!appKey) return;
         this.appKey = appKey;
 
@@ -300,6 +306,12 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
             if (installed) {
                 await this.server.driver.terminateApp(this.appKey);
             }
+        }
+
+        const appInfo = await this.server.driver.mobileGetActiveAppInfo();
+        const bundleId = appInfo['bundleId'];
+        if (bundleId !== 'com.apple.springboard') {
+            await this.server.driver.terminateApp(bundleId);
         }
 
         await this.server.driver.mobilePressButton({ name: 'home' });

--- a/typings/appium-xcuitest-driver/build/lib/driver.d.ts
+++ b/typings/appium-xcuitest-driver/build/lib/driver.d.ts
@@ -28,6 +28,7 @@ declare class XCUITestDriver extends BaseDriver {
     // TODO: HBsmith DEV-14062, DEV-14260
     public activateApp(bundleId: string): Promise<void>;
     public mobileLaunchApp(args: { bundleId: string }): Promise<any>;
+    public mobileGetActiveAppInfo(): Promise<any>;
     // public launchApp(bundleId: string): Promise<void>; // FIXME: NOT WORKING
     public terminateApp(bundleId: string): Promise<boolean>;
     public isAppInstalled(bundleId: string): Promise<boolean>;


### PR DESCRIPTION
### What is this PR for?

- 세션 시작 또는 종료 시 활성화된 앱이 있으면 종료시킴
- 한계: 모든 앱 종료는 구현이 어려움

### How should this be tested?

- vagrant up:
    - master: sachiel, db
- 라미엘 배포
```bash
cd <...>/ramiel
git checkout master
export BRANCH_WS_SCRCPY=DEV-14481
./provisioning.py on-premise
```
- 아이폰 연결
- 수동으로 폰에 앱을 띄움
- 앱키가 없이 세션 시작 -> 앱이 종료된 상태로 뜨는지 세션이 뜨는지 확인
- 임의의 앱을 실행한 상태에서 세션 종료
- 다시 세션 연결 -> 앱이 종료된 상태로 뜨는지 세션이 뜨는지 확인

### Screenshots (if appropriate)

https://user-images.githubusercontent.com/12525941/159840553-861da65e-d243-48b4-b437-0bd3408b4722.mov

