### PR TITLE
DEV-14479 sachiel: POST /real-devices/<device_id>/control/에서 exception 발생

### DIFF
--- a/src/server/appl-device/mw/WebDriverAgentProxy.ts
+++ b/src/server/appl-device/mw/WebDriverAgentProxy.ts
@@ -234,7 +234,7 @@ export class WebDriverAgentProxy extends Mw {
                     const userAgent = 'user-agent' in error.response ? error.response.data['user-agent'] : '';
                     msg = `사용 중인 장비입니다`;
                     if (userAgent) msg += ` (${userAgent})`;
-                } else if (503 === status) msg = `장비의 연결이 끊어져 있습니다`;
+                } else if (410 === status) msg = `장비의 연결이 끊어져 있습니다`;
                 error.message = msg;
                 throw error;
             });

--- a/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
+++ b/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
@@ -129,7 +129,7 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
                     const userAgent = 'user-agent' in error.response ? error.response.data['user-agent'] : '';
                     msg = `사용 중인 장비입니다`;
                     if (userAgent) msg += ` (${userAgent})`;
-                } else if (503 === status) msg = `장비의 연결이 끊어져 있습니다`;
+                } else if (410 === status) msg = `장비의 연결이 끊어져 있습니다`;
                 ws.close(4900, msg);
                 throw error;
             });


### PR DESCRIPTION
### What is this PR for?

- 장비 연결이 끊어져 있거나 점검 중일 경우 410 GONE 리턴
- 기존 503 에러는 서버 크래시에 사용하는 것이 컨텍스트에 맞음
- 참조)
    - https://github.com/HardBoiledSmith/sachiel/pull/1099
    - https://github.com/HardBoiledSmith/ws-scrcpy/pulls

### How should this be tested?

- db master vagrant up
- sachiel: `BRANCH=DEV-14479 vagrant up`
- 모든 유닛테스트 통과


