### PR TITLE
DEV-15125 build.config.override.json에서 iOS 설정 롤백

### DIFF
--- a/build.config.override.json
+++ b/build.config.override.json
@@ -1,4 +1,1 @@
-{
-  "INCLUDE_APPL": true,
-  "WDA_RUN_MJPEG_SERVER": true
-}
+{}


### PR DESCRIPTION
### What is this PR for?

- 잘못 커밋된 iOS 설정 롤백
- `build.config.override.json` 파일은 이미 커밋이 되어 있기에, `.gitignore`에 추가하는 것은 의미가 없음
- 여러 방법을 고민하였으나, 원격에서 파일을 유지하면서 로컬에서만 커밋을 무시하는 간단한 방법은 딱히 없음
- 참조) https://cppmaster.tistory.com/entry/Git%EC%97%90-tracking%EC%A4%91%EC%9D%B8-file%EC%9D%84-ignore-%ED%95%98%EB%8A%94-%EB%B0%A9%EB%B2%95
    1. 원격에서 삭제하고 로컬에서 .gitignore에 추가
    1. `git update-index --assume-unchanged [path]` -> clone 할 때마다 적용 필요
    1. `git update-index --skip-worktree [path]`  -> clone 할 때마다 적용 필요
- 대안 1~3이 적용이 복잡하거나 클론할 때마다 명령어를 실행해야 한다. 따라서 내용을 삭제하고 현행을 유지하기로 하였음