### PR TITLE
DEV-14939 [라미엘] WDA가 죽는 현상

### DIFF
--- a/src/app/applDevice/client/StreamClientMJPEG.ts
+++ b/src/app/applDevice/client/StreamClientMJPEG.ts
@@ -53,7 +53,7 @@ export class StreamClientMJPEG
 
     // TODO: HBsmith
     public onKeyEvent(key: string): void {
-        this.wdaProxy.requestWebDriverAgent(WDAMethod.SEND_A_KEY, { key });
+        this.wdaProxy.requestWebDriverAgent(WDAMethod.SEND_KEYS, { keys: key });
     }
 
     public onStop(ev?: string | Event): void {

--- a/src/app/applDevice/client/WdaProxyClient.ts
+++ b/src/app/applDevice/client/WdaProxyClient.ts
@@ -211,9 +211,7 @@ export class WdaProxyClient
     }
 
     public async sendKeys(keys: string): Promise<void> {
-        return this.requestWebDriverAgent(WDAMethod.SEND_KEYS, {
-            keys,
-        });
+        return this.requestWebDriverAgent(WDAMethod.SEND_KEYS, { keys });
     }
 
     public async pressButton(name: string): Promise<void> {

--- a/src/common/WDAMethod.ts
+++ b/src/common/WDAMethod.ts
@@ -6,7 +6,6 @@ export enum WDAMethod {
     APPIUM_SETTINGS = 'APPIUM_SETTINGS',
     SEND_KEYS = 'SEND_KEYS',
     // TODO: HBsmith
-    SEND_A_KEY = 'SEND_A_KEY',
     UNLOCK = 'UNLOCK',
     TERMINATE_APP = 'TERMINATE_APP',
     //

--- a/src/server/Utils.ts
+++ b/src/server/Utils.ts
@@ -73,7 +73,7 @@ export class Utils {
     public static async getProcessId(query: string): Promise<number | undefined> {
         let cmd = '';
         if (['darwin', 'linux'].includes(process.platform)) {
-            cmd = `pgrep -f ${query} | head -1`;
+            cmd = `ps -ef | grep -E '${query}' | grep -v grep | awk '{ print $2 }' | head -1`
         } else {
             throw new Error('Unsupported platform');
         }

--- a/src/server/appl-device/services/WDARunner.ts
+++ b/src/server/appl-device/services/WDARunner.ts
@@ -12,7 +12,6 @@ import { WdaStatus } from '../../../common/WdaStatus';
 import { Config } from '../../Config';
 import { Logger, Utils } from '../../Utils';
 import axios from 'axios';
-import { EventEmitter } from 'events';
 //
 
 const MJPEG_SERVER_PORT = 9100;
@@ -34,7 +33,6 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
 
     private wdaEvents: Array<Object> = [];
     private wdaEventInAction = false;
-    private wdaEventEmitter: EventEmitter = new EventEmitter();
     private wdaProcessId: number | undefined;
     //
 
@@ -102,7 +100,12 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
         this.logger = new Logger(udid, 'iOS');
         this.wdaProcessId = undefined;
         this.wdaEventInAction = false;
-        this.wdaEventEmitter.on('event', () => {
+
+        setInterval(() => {
+            if (this.wdaEventInAction || this.wdaEvents.length === 0) {
+                return;
+            }
+
             const driver = this.server?.driver;
             if (!driver) {
                 return;
@@ -115,12 +118,6 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
             (<Function> ev)(driver).finally(() => {
                 this.wdaEventInAction = false;
             });
-        });
-        setInterval(() => {
-            if (this.wdaEventInAction || this.wdaEvents.length === 0) {
-                return;
-            }
-            this.wdaEventEmitter.emit('event');
         }, 100);
         //
     }

--- a/src/server/appl-device/services/WDARunner.ts
+++ b/src/server/appl-device/services/WDARunner.ts
@@ -197,12 +197,6 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
                 });
                 return;
             // TODO: HBsmith
-            case WDAMethod.SEND_A_KEY:
-                const keys2 = args.keys;
-                this.wdaEvents.push((driver: XCUITestDriver) => {
-                    return driver.keys(keys2);
-                });
-                return;
             case WDAMethod.UNLOCK:
                 this.wdaEvents.push((driver: XCUITestDriver) => {
                     return driver.unlock();
@@ -369,8 +363,8 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
     }
 
     public async tearDownTest(): Promise<void> {
-        this.wdaEvents = []
         this.wdaEventInAction = false;
+        this.wdaEvents = [];
         
         if (!this.server) {
             this.logger.error('No Server at tearDownTest', this.udid);

--- a/src/server/appl-device/services/WDARunner.ts
+++ b/src/server/appl-device/services/WDARunner.ts
@@ -226,7 +226,10 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
                 wdaLocalPort: this.wdaLocalPort,
                 usePrebuiltWDA: true,
                 mjpegServerPort: remoteMjpegServerPort,
-                webDriverAgentUrl: webDriverAgentUrl, // TODO: HBsmith
+                // TODO: HBsmith
+                webDriverAgentUrl: webDriverAgentUrl,
+                waitForQuiescence: false,
+                //
             });
             // TODO: HBsmith
             this.wdaProcessId = await Utils.getProcessId(`xcodebuild.+${this.udid}`);


### PR DESCRIPTION
### What is this PR for?

- 다음의 이슈 해결 또는 완화:
    - WDA가 정상이나 ws-scrcpy로 iOS 세션 연결 시 갑자기 끊어짐 [경과 확인 중]
    - iOS 세션에서 연속으로 입력 시 WDA 프로세스가 죽음 [경과 확인 중]
    - iOS에 많은 입력 → WDA에서 처리하는 속도가 따라가지 못함. 간간히 롯데ON 앱 크래시 [경과 확인 중]
    - WDA 크래시 [경과 확인 중]
    - 입력이 많이 남은 상태에서 세션 종료 → 남은 명령과 TearDown 프로세스가 꼬임 → 다음 테스트에 영향 [경과 확인 중]
- 참조) https://hbsmith.atlassian.net/wiki/spaces/GEN/pages/2368929913/Ramiel#2022-5-16-WebDriverAgent-%ED%94%84%EB%A1%9C%EC%84%B8%EC%8A%A4%EA%B0%80-%EC%A3%BD%EA%B1%B0%EB%82%98-%EC%B2%98%EB%A6%AC-%EC%86%8D%EB%8F%84%EA%B0%80-%EB%96%A8%EC%96%B4%EC%A7%90

### How should this be tested?

프로비저닝 프로필에 등록된 iOS가 필요하여 선택사항임.
- master vagrant up: db, sachiel
- `BRANCH_WS_SCRCPY=DEV-14939 ./provisioning on-premise`
- iOS 세션 접속
- 세션 접속 -> 롯데ON 앱 열기 -> 이전 대비 반응 속도 향상 확인
- 세션 접속 -> 롯데ON 앱 열기 -> 0.5초 미만 간격을 빠르게 30회 카테고리 항목을 터치 -> WDA가 죽지 않는 것 확인. (50회 반복 시 죽음)

