### PR TITLE
DEV-14082 [라미엘] 외부에서 apk 설치 기능

### DIFF
--- a/src/app/controlMessage/CommandControlMessage.ts
+++ b/src/app/controlMessage/CommandControlMessage.ts
@@ -193,13 +193,31 @@ export class CommandControlMessage extends ControlMessage {
         return { id, state, chunk, fileName, fileSize };
     }
 
-    // TODO: HBsmith DEV-14439
+    // TODO: HBsmith
     public static createAdbControlCommand(value: number): CommandControlMessage {
         const event = new CommandControlMessage(ControlMessage.TYPE_ADB_CONTROL);
         let offset = 0;
         const buffer = new Buffer(1 + 1);
         offset += buffer.writeUInt8(event.type, offset);
         buffer.writeUInt8(value, offset);
+        event.buffer = buffer;
+        return event;
+    }
+
+    public static createAdbInstallCommand(fileName: string): CommandControlMessage {
+        const event = new CommandControlMessage(ControlMessage.TYPE_ADB_CONTROL);
+        const textBytes: Uint8Array = Util.stringToUtf8ByteArray(fileName);
+        const textLength = textBytes ? textBytes.length : 0;
+        let offset = 0;
+        const buffer = Buffer.alloc(1 + 1 + 4 + textLength);
+        offset = buffer.writeUInt8(event.type, offset);
+        offset = buffer.writeUInt8(ControlMessage.TYPE_ADB_INSTALL_APK, offset);
+        offset = buffer.writeInt32BE(textLength, offset);
+        if (textBytes) {
+            textBytes.forEach((byte: number, index: number) => {
+                buffer.writeUInt8(byte, index + offset);
+            });
+        }
         event.buffer = buffer;
         return event;
     }

--- a/src/app/controlMessage/ControlMessage.ts
+++ b/src/app/controlMessage/ControlMessage.ts
@@ -21,6 +21,7 @@ export class ControlMessage {
     public static TYPE_ADB_CONTROL = 200;
     public static TYPE_ADB_CONTROL_SWIPE_UP = 0;
     public static TYPE_ADB_CONTROL_SWIPE_DOWN = 1;
+    public static TYPE_ADB_INSTALL_APK = 2;
     //
 
     constructor(readonly type: number) {}

--- a/src/app/googDevice/filePush/FilePushHandler.ts
+++ b/src/app/googDevice/filePush/FilePushHandler.ts
@@ -1,6 +1,7 @@
 import { DragAndDropHandler, DragEventListener } from '../DragAndDropHandler';
 import { FilePushStream, PushResponse } from './FilePushStream';
 import { FilePushResponseStatus } from './FilePushResponseStatus';
+import {CommandControlMessage} from "../../controlMessage/CommandControlMessage";
 
 type Resolve = (response: PushResponse) => void;
 
@@ -104,6 +105,10 @@ export default class FilePushHandler implements DragEventListener {
                         error: false,
                         finished: true,
                     });
+                    // TODO: HBsmith
+                    const message = CommandControlMessage.createAdbInstallCommand(fileName);
+                    this.filePushStream.sendEvent(message);
+                    //
                 }
                 console.log(TAG, `File "${fileName}" uploaded in ${Date.now() - start}ms`);
                 return;

--- a/src/app/googDevice/filePush/FilePushStream.ts
+++ b/src/app/googDevice/filePush/FilePushStream.ts
@@ -1,4 +1,7 @@
 import { TypedEmitter } from '../../../common/TypedEmitter';
+// TODO: HBsmith
+import { CommandControlMessage } from "../../controlMessage/CommandControlMessage";
+//
 
 export type PushResponse = { id: number; code: number };
 
@@ -10,6 +13,11 @@ interface FilePushStreamEvents {
 export abstract class FilePushStream extends TypedEmitter<FilePushStreamEvents> {
     public abstract hasConnection(): boolean;
     public abstract isAllowedFile(file: File): boolean;
+    // TODO: HBsmith
+    public sendEvent(message: CommandControlMessage): void {
+        console.log(`Method not implemented: ${message}`);
+    };
+    //
     public abstract sendEventNew(params: { id: number }): void;
     public abstract sendEventStart(params: { id: number; fileName: string; fileSize: number }): void;
     public abstract sendEventFinish(params: { id: number }): void;

--- a/src/app/googDevice/filePush/ScrcpyFilePushStream.ts
+++ b/src/app/googDevice/filePush/ScrcpyFilePushStream.ts
@@ -20,6 +20,12 @@ export class ScrcpyFilePushStream extends FilePushStream {
         return (type && ALLOWED_TYPES.includes(type)) || (!type && ALLOWED_NAME_RE.test(name));
     }
 
+    // TODO: HBsmith
+    public sendEvent(message: CommandControlMessage): void {
+        this.streamReceiver.sendEvent(message);
+    }
+    //
+
     public sendEventAppend({ id, chunk }: { id: number; chunk: Uint8Array }): void {
         const appendParams = { id, chunk, state: FilePushState.APPEND };
         this.streamReceiver.sendEvent(CommandControlMessage.createPushFileCommand(appendParams));

--- a/src/app/googDevice/toolbox/DroidToolBox2.ts
+++ b/src/app/googDevice/toolbox/DroidToolBox2.ts
@@ -52,6 +52,11 @@ const BUTTONS = [
         icon: BtnDoubleDown,
         type: 'CommandControlMessage',
     },
+    {
+        title: 'InstallApk',
+        icon: BtnDoubleDown,
+        type: 'CommandControlMessage',
+    },
 ];
 
 export class ToolBoxButton2 extends ToolBoxElement<HTMLButtonElement> {
@@ -147,6 +152,15 @@ export class DroidToolBox2 {
                         const event = CommandControlMessage.createAdbControlCommand(
                             ControlMessage.TYPE_ADB_CONTROL_SWIPE_DOWN,
                         );
+                        client.sendMessage(event);
+                        break;
+                    }
+                    case 'InstallApk': {
+                        const fileName = prompt('input apk file name');
+                        if (!fileName) {
+                            break;
+                        }
+                        const event = CommandControlMessage.createAdbInstallCommand(fileName);
                         client.sendMessage(event);
                         break;
                     }

--- a/src/app/googDevice/toolbox/DroidToolBox2.ts
+++ b/src/app/googDevice/toolbox/DroidToolBox2.ts
@@ -52,11 +52,6 @@ const BUTTONS = [
         icon: BtnDoubleDown,
         type: 'CommandControlMessage',
     },
-    {
-        title: 'InstallApk',
-        icon: BtnDoubleDown,
-        type: 'CommandControlMessage',
-    },
 ];
 
 export class ToolBoxButton2 extends ToolBoxElement<HTMLButtonElement> {
@@ -152,15 +147,6 @@ export class DroidToolBox2 {
                         const event = CommandControlMessage.createAdbControlCommand(
                             ControlMessage.TYPE_ADB_CONTROL_SWIPE_DOWN,
                         );
-                        client.sendMessage(event);
-                        break;
-                    }
-                    case 'InstallApk': {
-                        const fileName = prompt('input apk file name');
-                        if (!fileName) {
-                            break;
-                        }
-                        const event = CommandControlMessage.createAdbInstallCommand(fileName);
                         client.sendMessage(event);
                         break;
                     }

--- a/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
+++ b/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
@@ -218,38 +218,61 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
                     return;
                 }
 
-                let isLandscape = false;
-                device
-                    .runShellCommandAdbKit('dumpsys window displays | grep mCurrentRotation | tail -1')
-                    .then((rr) => {
-                        if (rr) {
-                            const [oo] = rr.match(/\d+/);
-                            isLandscape = oo === '90' || oo === '270';
-                        }
-                        return device.runShellCommandAdbKit('wm size | tail -1');
-                    })
-                    .then((rr) => {
-                        let [, ww, hh] = rr.match(/(\d+)x(\d+)/);
-                        if (isLandscape) {
-                            [ww, hh] = [hh, ww];
-                        }
+                switch (value) {
+                    case ControlMessage.TYPE_ADB_INSTALL_APK: {
+                        const bb = event.data.slice(6);
+                        const fileName = bb.toString();
+                        const pathToApk = `/data/local/tmp/${fileName}`;
+                        // AdbKit.install is not working
+                        device
+                            .runShellCommandAdbKit(`pm install -r ${pathToApk}`)
+                            .then(() => {
+                                this.logger.info(`success to install apk: ${fileName}`);
+                                return device.runShellCommandAdbKit(`rm -f ${pathToApk}`);
+                            })
+                            .then(() => {
+                                this.logger.info(`remove the installed apk: ${pathToApk}`);
+                            })
+                            .catch((ee) => {
+                                this.logger.error(`failed to install apk: ${fileName}`, ee);
+                            });
+                        return;
+                    }
+                    case ControlMessage.TYPE_ADB_CONTROL_SWIPE_DOWN:
+                    case ControlMessage.TYPE_ADB_CONTROL_SWIPE_UP: {
+                        let isLandscape = false;
+                        device
+                            .runShellCommandAdbKit('dumpsys window displays | grep mCurrentRotation | tail -1')
+                            .then((rr) => {
+                                if (rr) {
+                                    const [oo] = rr.match(/\d+/);
+                                    isLandscape = oo === '90' || oo === '270';
+                                }
+                                return device.runShellCommandAdbKit('wm size | tail -1');
+                            })
+                            .then((rr) => {
+                                let [, ww, hh] = rr.match(/(\d+)x(\d+)/);
+                                if (isLandscape) {
+                                    [ww, hh] = [hh, ww];
+                                }
 
-                        const xx = parseInt(ww) / 2;
-                        const y1 = parseInt(hh) / 4;
-                        const y2 = (parseInt(hh) * 4) / 5;
-                        switch (value) {
-                            case ControlMessage.TYPE_ADB_CONTROL_SWIPE_UP:
-                                device.runShellCommandAdbKit(`input swipe ${xx} ${y2} ${xx} ${y1} 500`);
-                                break;
-                            case ControlMessage.TYPE_ADB_CONTROL_SWIPE_DOWN:
-                                device.runShellCommandAdbKit(`input swipe ${xx} ${y1} ${xx} ${y2} 500`);
-                                break;
-                        }
-                    })
-                    .catch((error) => {
-                        this.logger.error(error);
-                    });
-                return;
+                                const xx = parseInt(ww) / 2;
+                                let y1 = parseInt(hh) / 4;
+                                let y2 = (parseInt(hh) * 4) / 5;
+                                if (value === ControlMessage.TYPE_ADB_CONTROL_SWIPE_UP) {
+                                    [y1, y2] = [y2, y1];
+                                }
+
+                                device.runShellCommandAdbKit(`input swipe ${xx} ${y1} ${xx} ${y2} 500`).then(() => {
+                                    this.logger.info(`Success to swipe: ${xx} ${y1} ${xx} ${y2} 500`);
+                                });
+                            })
+                            .catch((error) => {
+                                this.logger.error(error);
+                            });
+                        return;
+                    }
+                }
             }
         } catch (error) {
             this.logger.error(error);

--- a/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
+++ b/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
@@ -225,16 +225,16 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
                         const pathToApk = `/data/local/tmp/${fileName}`;
                         // AdbKit.install is not working
                         device
-                            .runShellCommandAdbKit(`pm install -r ${pathToApk}`)
+                            .runShellCommandAdbKit(`pm install -r '${pathToApk}'`)
                             .then(() => {
                                 this.logger.info(`success to install apk: ${fileName}`);
-                                return device.runShellCommandAdbKit(`rm -f ${pathToApk}`);
+                                return device.runShellCommandAdbKit(`rm -f '${pathToApk}'`);
                             })
                             .then(() => {
-                                this.logger.info(`remove the installed apk: ${pathToApk}`);
+                                this.logger.info(`remove the installed apk: '${pathToApk}'`);
                             })
                             .catch((ee) => {
-                                this.logger.error(`failed to install apk: ${fileName}`, ee);
+                                this.logger.error(`failed to install apk: '${fileName}'`, ee);
                             });
                         return;
                     }


### PR DESCRIPTION
### What is this PR for?

- APK 설치 기능 구현
    - Drag & Drop으로 APK 파일 설치 기능은 이미 구현되어 있음
    - 원래 APK 설치는 shell로 수행하라고 가이드 되어 있음 -> 자동으로 설치를 트리거하도록 기능 추가

### How should this be tested?

- master up: db, sachiel
- branch up: `BRANCH_WS_SCRCPY=DEV-14082 ./provisioning.py on-premise`
- 인터넷에서 임의의 APK 다운로드
- 안드로이드 폰 연결
- 세션 연결
- 다운받은 APK 파일을 화면에 drag & drop
- 설치 완료 확인

### Screenshots (if appropriate)

https://user-images.githubusercontent.com/12525941/170008384-87fd0b82-4545-4ea5-a72e-6f427106e4b6.mov


