### PR TITLE
DEV-15167 [라미엘] iOS 속도 저하 현상 해결을 위한 핫픽스

### DIFF
--- a/src/server/appl-device/services/WDARunner.ts
+++ b/src/server/appl-device/services/WDARunner.ts
@@ -31,7 +31,7 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
     private appKey: string;
     private logger: Logger;
 
-    private wdaEvents: Array<Object> = [];
+    private wdaEvents: Array<unknown> = [];
     private wdaEventInAction = false;
     private wdaProcessId: number | undefined;
     //
@@ -115,7 +115,7 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
                 return;
             }
             this.wdaEventInAction = true;
-            (<Function> ev)(driver).finally(() => {
+            (<Function>ev)(driver).finally(() => {
                 this.wdaEventInAction = false;
             });
         }, 100);
@@ -163,7 +163,7 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
             case WDAMethod.GET_SCREEN_WIDTH:
                 return WdaRunner.getScreenWidth(this.udid, driver);
             case WDAMethod.CLICK:
-                const [ x, y ] = [ args.x, args.y ];
+                const [x, y] = [args.x, args.y];
                 this.wdaEvents.push((driver: XCUITestDriver) => {
                     return driver.performTouch([{ action: 'tap', options: { x: x, y: y } }]);
                 });
@@ -177,7 +177,7 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
             case WDAMethod.SCROLL:
                 const { from, to } = args;
                 this.wdaEvents.push((driver: XCUITestDriver) => {
-                        return driver.performTouch([
+                    return driver.performTouch([
                         { action: 'press', options: { x: from.x, y: from.y } },
                         { action: 'wait', options: { ms: 500 } },
                         { action: 'moveTo', options: { x: to.x, y: to.y } },
@@ -243,7 +243,6 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
                 mjpegServerPort: remoteMjpegServerPort,
                 // TODO: HBsmith
                 webDriverAgentUrl: webDriverAgentUrl,
-                waitForQuiescence: false,
                 //
             });
             // TODO: HBsmith
@@ -362,7 +361,7 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
     public async tearDownTest(): Promise<void> {
         this.wdaEventInAction = false;
         this.wdaEvents = [];
-        
+
         if (!this.server) {
             this.logger.error('No Server at tearDownTest', this.udid);
             return;


### PR DESCRIPTION
### What is this PR for?

- 튜닝값 롤백: `waitForQuiescence`
- 사유
    - 앱 시작 기능이 잘 동작하지 않음
    - 시간 경과 후 WDA 반응 속도가 매우 떨어짐

### 패치 절차 검토
- OP 영향을 최소화 하기 위해 아래의 절차를 제안함
- 대상: iOS 서비스가 활성화된 맥미니만
- 절차: OP merge -> 수동으로 ws-scrcpy-ios만 업데이트 후 재시작:
    ```bash
    cd /opt/ramiel/ws-scrcpy-ios; git pull
    kill -9 $(ps -ef |grep xcodebuild |grep -v grep| awk '{print $2}')
    launchctl stop ramiel.ws-scrcpy-ios.hbsmith.io
    ```