### PR TITLE
DEV-15343 [라마엘] 초기화 완료, 검은 바탕

### DIFF
--- a/src/server/mw/MjpegProxyFactory.ts
+++ b/src/server/mw/MjpegProxyFactory.ts
@@ -37,6 +37,7 @@ export class MjpegProxyFactory {
             console.error('msg: ' + data.msg);
             console.error('url: ' + data.url);
         });
+        proxy.proxyRequest(req, res);
         //
     };
 }

--- a/src/server/mw/MjpegProxyFactory.ts
+++ b/src/server/mw/MjpegProxyFactory.ts
@@ -4,43 +4,39 @@ import { WdaRunner } from '../appl-device/services/WDARunner';
 import { WdaStatus } from '../../common/WdaStatus';
 
 export class MjpegProxyFactory {
-    private static instances: Map<string, MjpegProxy> = new Map();
     proxyRequest = async (req: Request, res: Response): Promise<void> => {
         const { udid } = req.params;
         if (!udid) {
             res.destroy();
             return;
         }
-        let proxy = MjpegProxyFactory.instances.get(udid);
-        if (!proxy) {
-            const wda = await WdaRunner.getInstance(udid);
-            if (!wda.isStarted()) {
-                // FIXME: `wda.start()` should resolve on 'started'
-                const startPromise = new Promise((resolve) => {
-                    const onStatusChange = ({ status }: { status: WdaStatus }) => {
-                        if (status === WdaStatus.STARTED) {
-                            wda.off('status-change', onStatusChange);
-                            resolve();
-                        }
-                    };
-                    wda.on('status-change', onStatusChange);
-                });
-                await wda.start();
-                await startPromise;
-            }
-            const port = wda.mjpegPort;
-            const url = `http://127.0.0.1:${port}`;
-            proxy = new MjpegProxy(url);
-            proxy.on('streamstop', (): void => {
-                wda.release();
-                MjpegProxyFactory.instances.delete(udid);
+
+        // TODO: HBsmith
+        const wda = await WdaRunner.getInstance(udid);
+        if (!wda.isStarted()) {
+            // FIXME: `wda.start()` should resolve on 'started'
+            const startPromise = new Promise((resolve) => {
+                const onStatusChange = ({ status }: { status: WdaStatus }) => {
+                    if (status === WdaStatus.STARTED) {
+                        wda.off('status-change', onStatusChange);
+                        resolve();
+                    }
+                };
+                wda.on('status-change', onStatusChange);
             });
-            proxy.on('error', (data: { msg: Error; url: string }): void => {
-                console.error('msg: ' + data.msg);
-                console.error('url: ' + data.url);
-            });
-            MjpegProxyFactory.instances.set(udid, proxy);
+            await wda.start();
+            await startPromise;
         }
-        proxy.proxyRequest(req, res);
+        const port = wda.mjpegPort;
+        const url = `http://127.0.0.1:${port}`;
+        const proxy = new MjpegProxy(url);
+        proxy.on('streamstop', (): void => {
+            wda.release();
+        });
+        proxy.on('error', (data: { msg: Error; url: string }): void => {
+            console.error('msg: ' + data.msg);
+            console.error('url: ' + data.url);
+        });
+        //
     };
 }


### PR DESCRIPTION
### What is this PR for?

- MJPEG proxy를 캐싱하지 않도록 함

### How should this be tested?

- iOS 테스트 환경 구성
- 다음 절차를 10회 반복 후, `초기화 완료, 검은 바탕` 증상이 발생하는지 확인:
    - iOS에 WDA 실행 확인 -> ws-scrcpy-ios로 세션 접속 확인 -> WDA 강제 종료 -> ws-scrcpy-ios로 세션 접속

### Screenshots (if appropriate)

- 다음 화면이 노출되지 않아야 함:
![image](https://user-images.githubusercontent.com/12525941/174011814-819af21c-c9fd-4a13-a4c0-6fc97878926f.png)
