### PR TITLE
DEV-15351 [라미엘] iOS장비 잠금이 해제되지 않음

### DIFF
--- a/src/server/appl-device/mw/WebDriverAgentProxy.ts
+++ b/src/server/appl-device/mw/WebDriverAgentProxy.ts
@@ -84,13 +84,19 @@ export class WebDriverAgentProxy extends Mw {
                 if (this.wda.isStarted()) {
                     this.onStatusChange(command, WdaStatus.STARTED);
                     // TODO: HBsmith
-                    this.wda.setUpTest(this.appKey);
+                    this.wda.setUpTest(this.appKey).catch((e: Error) => {
+                        this.logger.error(e);
+                        this.wda?.emit('status-change', { status: WdaStatus.ERROR, text: '초기화 실패' });
+                    });
                     //
                 } else {
                     // TODO: HBsmith
                     this.onStatusChange(command, WdaStatus.STARTED);
                     this.wda.start().then(() => {
-                        this.wda?.setUpTest(this.appKey);
+                        this.wda?.setUpTest(this.appKey).catch((e: Error) => {
+                            this.logger.error(e);
+                            this.wda?.emit('status-change', { status: WdaStatus.ERROR, text: '초기화 실패' });
+                        });
                     });
                     //
                 }
@@ -177,7 +183,9 @@ export class WebDriverAgentProxy extends Mw {
 
         new Promise((resolve) => setTimeout(resolve, 3000))
             .then(() => {
-                return this.wda?.tearDownTest();
+                return this.wda?.tearDownTest().catch((e: Error) => {
+                    this.logger.error(e);
+                });
             })
             .finally(() => {
                 super.release();

--- a/src/server/appl-device/services/WDARunner.ts
+++ b/src/server/appl-device/services/WDARunner.ts
@@ -57,7 +57,7 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
                 console.error('Server Error:', args);
             });
             server.on('close', (...args: any[]) => {
-                console.error('Server Close:', args);
+                console.info('Server Close:', args);
             });
             this.servers.set(udid, server);
         }
@@ -353,10 +353,14 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
             }
             this.wdaEventInAction = true;
             this.emit('status-change', { status: WdaStatus.IN_ACTION, text: '제어 중' });
-            (<Function>ev)(driver).finally(() => {
-                this.wdaEventInAction = false;
-                this.emit('status-change', { status: WdaStatus.END_ACTION, text: '제어 완료' });
-            });
+            (<Function>ev)(driver)
+                .catch((e: Error) => {
+                    this.logger.error(e);
+                })
+                .finally(() => {
+                    this.wdaEventInAction = false;
+                    this.emit('status-change', { status: WdaStatus.END_ACTION, text: '제어 완료' });
+                });
         }, 100);
         this.wdaProcessId = await Utils.getProcessId(`xcodebuild.+${this.udid}`);
         this.wdaProcessTimer = setInterval(() => {


### PR DESCRIPTION
### What is this PR for?

- iOS 장비 잠금이 풀리지 않는 이슈 해결
- 세션 초기화/종료 중 WDA down 시 ws-scrcpy가 죽는 문제 해결
- 참조: https://hbsmith.atlassian.net/wiki/spaces/GEN/pages/2368929913/Ramiel#20220619-iOS-%EC%9E%A5%EB%B9%84-%EC%9E%A0%EA%B8%88%EC%9D%B4-%ED%92%80%EB%A6%AC%EC%A7%80-%EC%95%8A%EB%8A%94-%ED%98%84%EC%83%81-%EB%8B%A4%EB%B0%9C

### How should this be tested?

- 테스트 가능한 iOS가 있을 경우 선택적으로 수행
- iOS 장비 연결
- 라미엘 배포
```bash
export BRANCH_WS_SCRCPY=DEV-15351
./provisioning.py on-premise
```
- 세션 연결 -> 장비 초기화 중 메시지 확인
- WDA kill : `kill -9 $(ps -ef | grep xcodebuild | grep -v grep | awk '{print $2}')`
- ws-scrcpy가 죽지 않는지 확인

### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/12525941/174725402-e4ec7d45-048b-4d09-9990-2baa3560f49c.png)

<img width="533" alt="image" src="https://user-images.githubusercontent.com/12525941/174725423-de73b752-41ff-4ab6-8b1b-e4ebc6f6bb80.png">



