### PR TITLE
DEV-15491 [라미엘] 초기화 완료, 검은 바탕 #2 - invalid session id로 인해 발생 확인

### DIFF
--- a/src/server/Utils.ts
+++ b/src/server/Utils.ts
@@ -73,7 +73,7 @@ export class Utils {
     public static async getProcessId(query: string): Promise<number | undefined> {
         let cmd = '';
         if (['darwin', 'linux'].includes(process.platform)) {
-            cmd = `ps -ef | grep -E '${query}' | grep -v grep | awk '{ print $2 }' | head -1`
+            cmd = `ps -ef | grep -E '${query}' | grep -v grep | awk '{ print $2 }' | head -1`;
         } else {
             throw new Error('Unsupported platform');
         }

--- a/src/server/appl-device/mw/WebDriverAgentProxy.ts
+++ b/src/server/appl-device/mw/WebDriverAgentProxy.ts
@@ -92,12 +92,21 @@ export class WebDriverAgentProxy extends Mw {
                 } else {
                     // TODO: HBsmith
                     this.onStatusChange(command, WdaStatus.STARTED);
-                    this.wda.start().then(() => {
-                        this.wda?.setUpTest(this.appKey).catch((e: Error) => {
+                    this.wda
+                        .start()
+                        .then(() => {
+                            this.wda?.setUpTest(this.appKey).catch((e: Error) => {
+                                this.logger.error(e);
+                                this.wda?.emit('status-change', { status: WdaStatus.ERROR, text: '초기화 실패' });
+                            });
+                        })
+                        .catch((e: Error) => {
                             this.logger.error(e);
-                            this.wda?.emit('status-change', { status: WdaStatus.ERROR, text: '초기화 실패' });
+                            this.wda?.emit('status-change', {
+                                status: WdaStatus.ERROR,
+                                text: 'WebDrierAgent 재실행 중. 5분 뒤 다시 시도해 주세요.',
+                            });
                         });
-                    });
                     //
                 }
             })

--- a/src/server/mw/MjpegProxyFactory.ts
+++ b/src/server/mw/MjpegProxyFactory.ts
@@ -24,7 +24,9 @@ export class MjpegProxyFactory {
                 };
                 wda.on('status-change', onStatusChange);
             });
-            await wda.start();
+            try {
+                await wda.start();
+            } catch (e) {}
             await startPromise;
         }
         const port = wda.mjpegPort;


### PR DESCRIPTION
### What is this PR for?

- 버그 수정: WDA 재시작 시 높은 빈도로 검은화면 발생 후 회복되지 않음
    - 해결: holders 로직 폐지. MJPEGProxyFactory에 의한 세션은 holders 감소가 적용되지 않음
- 예외처리 추가: WDA가 죽은 뒤, API 서버에 반영되기 전에 세션 접속 시 서버 크래시

### How should this be tested?

프로비저닝 프로필에 등록된 iOS가 있을 경우 선택적으로 수행
- 환경 구축
    - 라미엘 환경 배포
    ```bash
    export BRANCH_WS_SCRCPY=DEV-15491
    ./provisioning.py on-premise
    ```
    - 아이폰 연결
- 재현
    - iOS 세션 연결했다가 종료 후 6초 대기
    - wda 프로세스 kill: `kill -9 $(ps -ef | grep xcodebuild | grep -v grep | awk '{print $2}')`
    - iOS 세션 다시 연결
    - 정상 연결 확인
    - ws-scrcpy가 크래시 되지 말아야 함 



