### PR TITLE
DEV-15664 [라미엘] iOS setUpTest 중 앱 시작 시점부터 화면을 보여줌

### DIFF
--- a/src/app/applDevice/client/StreamClient.ts
+++ b/src/app/applDevice/client/StreamClient.ts
@@ -202,6 +202,7 @@ export abstract class StreamClient<T extends ParamsStream> extends BaseClient<T,
                 this.logWdaStatus(data.status, data.text);
                 break;
             case WdaStatus.SET_UP:
+            case WdaStatus.SET_UP_SCREEN_ON:
             case WdaStatus.END_SET_UP:
                 this.logWdaStatus(data.status, data.text);
                 const videoLayer = document.getElementById('video-layer');
@@ -210,7 +211,7 @@ export abstract class StreamClient<T extends ParamsStream> extends BaseClient<T,
                 }
                 if (data.status === WdaStatus.SET_UP) {
                     videoLayer.style.display = 'none';
-                } else if (data.status === WdaStatus.END_SET_UP) {
+                } else {
                     videoLayer.style.display = '';
                 }
                 break;

--- a/src/app/applDevice/client/StreamClient.ts
+++ b/src/app/applDevice/client/StreamClient.ts
@@ -201,6 +201,15 @@ export abstract class StreamClient<T extends ParamsStream> extends BaseClient<T,
             case WdaStatus.END_ACTION:
                 this.logWdaStatus(data.status, data.text);
                 break;
+            case WdaStatus.SET_UP_DEVICE_INFO:
+                if (data.text) {
+                    this.deviceName = data.text;
+                }
+                const headerText = document.getElementById('control-header-device-name-text');
+                if (headerText) {
+                    headerText.textContent = `${this.deviceName} (${this.udid})`;
+                }
+                break;
             case WdaStatus.SET_UP:
             case WdaStatus.SET_UP_SCREEN_ON:
             case WdaStatus.END_SET_UP:

--- a/src/app/applDevice/client/StreamClient.ts
+++ b/src/app/applDevice/client/StreamClient.ts
@@ -178,10 +178,18 @@ export abstract class StreamClient<T extends ParamsStream> extends BaseClient<T,
         return this.waitForWda;
     }
 
-    protected handleWdaStatus = (message: MessageRunWdaResponse): void => {
-        // TODO: HBsmith
+    // TODO: HBsmith
+    private logWdaStatus(status: WdaStatus, text: string | undefined): void {
         const statusText = document.getElementById('control-header-device-status-text');
-        //
+
+        let msg = `[${status}]`;
+        if (!!text) msg += ` ${text}`;
+        if (statusText) statusText.textContent = msg;
+        this.emit('wda:status', status);
+    }
+    //
+
+    protected handleWdaStatus = (message: MessageRunWdaResponse): void => {
         const data = message.data;
         this.setWdaStatusNotification(data.status);
         switch (data.status) {
@@ -191,17 +199,23 @@ export abstract class StreamClient<T extends ParamsStream> extends BaseClient<T,
             case WdaStatus.ERROR:
             case WdaStatus.IN_ACTION:
             case WdaStatus.END_ACTION:
-                // TODO: HBsmith
-                let msg = `[${data.status}]`;
-                if (!!data.text) msg += ` ${data.text}`;
-                if (statusText) statusText.textContent = msg;
-                //
-                this.emit('wda:status', data.status);
+                this.logWdaStatus(data.status, data.text);
+                break;
+            case WdaStatus.SET_UP:
+            case WdaStatus.END_SET_UP:
+                this.logWdaStatus(data.status, data.text);
+                const videoLayer = document.getElementById('video-layer');
+                if (!videoLayer) {
+                    break;
+                }
+                if (data.status === WdaStatus.SET_UP) {
+                    videoLayer.style.display = 'none';
+                } else if (data.status === WdaStatus.END_SET_UP) {
+                    videoLayer.style.display = '';
+                }
                 break;
             default:
-                // TODO: HBsmith
-                if (statusText) statusText.textContent = status;
-                //
+                this.logWdaStatus(data.status, data.text);
                 throw Error(`Unknown WDA status: '${status}'`);
         }
     };

--- a/src/app/player/MjpegPlayer.ts
+++ b/src/app/player/MjpegPlayer.ts
@@ -14,6 +14,7 @@ export class MjpegPlayer extends BasePlayer {
             tag.id = id;
         }
         tag.className = 'video-layer';
+        tag.id = 'video-layer';
         return tag;
     }
 

--- a/src/common/WdaStatus.ts
+++ b/src/common/WdaStatus.ts
@@ -7,6 +7,7 @@ export enum WdaStatus {
     IN_ACTION = 'IN_ACTION',
     END_ACTION = 'END_ACTION',
     SET_UP = 'SET_UP',
+    SET_UP_DEVICE_INFO = 'SET_UP_DEVICE_INFO',
     SET_UP_SCREEN_ON = 'SET_UP_SCREEN_ON',
     END_SET_UP = 'END_SET_UP',
     //

--- a/src/common/WdaStatus.ts
+++ b/src/common/WdaStatus.ts
@@ -7,6 +7,7 @@ export enum WdaStatus {
     IN_ACTION = 'IN_ACTION',
     END_ACTION = 'END_ACTION',
     SET_UP = 'SET_UP',
+    SET_UP_SCREEN_ON = 'SET_UP_SCREEN_ON',
     END_SET_UP = 'END_SET_UP',
     //
 }

--- a/src/common/WdaStatus.ts
+++ b/src/common/WdaStatus.ts
@@ -6,5 +6,7 @@ export enum WdaStatus {
     ERROR = 'ERROR',
     IN_ACTION = 'IN_ACTION',
     END_ACTION = 'END_ACTION',
+    SET_UP = 'SET_UP',
+    END_SET_UP = 'END_SET_UP',
     //
 }

--- a/src/server/appl-device/services/WDARunner.ts
+++ b/src/server/appl-device/services/WDARunner.ts
@@ -302,7 +302,7 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
     }
 
     public async setUpTest(appKey: string): Promise<void> {
-        this.emit('status-change', { status: WdaStatus.IN_ACTION, text: '장비 초기화 중' });
+        this.emit('status-change', { status: WdaStatus.SET_UP, text: '장비 초기화 중' });
 
         this.appKey = appKey;
         this.wdaEventInAction = true;
@@ -395,7 +395,7 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
             });
         }, 100);
 
-        this.emit('status-change', { status: WdaStatus.END_ACTION, text: '장비 초기화 완료' });
+        this.emit('status-change', { status: WdaStatus.END_SET_UP, text: '장비 초기화 완료' });
     }
 
     public async tearDownTest(): Promise<void> {

--- a/src/server/appl-device/services/WDARunner.ts
+++ b/src/server/appl-device/services/WDARunner.ts
@@ -336,6 +336,8 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
                 this.logger.info(`setUpTest: Terminate the app - ${this.appKey}`);
                 await this.server.driver.terminateApp(this.appKey);
 
+                this.emit('status-change', { status: WdaStatus.SET_UP_SCREEN_ON, text: '장비 초기화 중 - 앱 시작' });
+
                 this.logger.info(`setUpTest: Launch the app - ${this.appKey}`);
                 await this.server.driver.mobileLaunchApp({ bundleId: this.appKey });
                 this.logger.info(`setUpTest: Activate the app - ${this.appKey}`);


### PR DESCRIPTION
### What is this PR for?

- 필요성
    - iOS 세션 시작 시, 앱키가 주어질 경우, 완벽한 종료를 위해 앱을 강제로 실행 후 종료를 시킴
    - gendo에서 때떄로 이 과정을 앱 실행 완료로 인식할 때가 있음
    - 이를 방지하기 위한 PR
- setUpTest 중 앱 시작 시점부터 화면을 보여줌
- (OPTIONAL) 장비 Alias 노출 (없을 경우 model)

### How should this be tested?

- 배포: `BRANCH_WS_SCRCPY=DEV-15664 ./provisioning.py on-premise`
- 앱키를 주는 옵션으로 세션 접속:
    - 예시) http://localhost:28100/?app_key=com.lotte.smartwish&user-agent=HELLO_WORL22222222D
#!action=stream-mjpeg&player=mjpeghttp&udid=00008020-00094C693A33002E
- 앱 스플래시가 뜨는 시점부터 화면이 켜지는지 확인

### Screenshots (if appropriate)

https://user-images.githubusercontent.com/12525941/178931996-0a0c37b7-3ed0-459c-858d-36e9f3a36d34.mov
