### PR TITLE
DEV-16083 [라미엘] 재시도 사이드 이펙트: 잠김 상태일 때 에러메시지 이상

### DIFF
--- a/src/server/appl-device/mw/WebDriverAgentProxy.ts
+++ b/src/server/appl-device/mw/WebDriverAgentProxy.ts
@@ -109,8 +109,7 @@ export class WebDriverAgentProxy extends Mw {
                     command,
                     WdaStatus.ERROR,
                     -1,
-                    e.text || '알 수 없는 이유로 장비 초기화에 실패하였습니다.',
-                    e.message,
+                    e.text || e.message || '알 수 없는 이유로 장비 초기화에 실패하였습니다.',
                 );
                 this.ws.close(4900, e.message);
                 this.logger.error(e);


### PR DESCRIPTION
### What is this PR for?

- 에러 로깅 중복 제거
- 참조)  https://hbsmith.atlassian.net/browse/DEV-16083

### How should this be tested?

- db, sachiel 배포
- 모든 장비 잠금으로 설정
    ```sql
    update hbsmith.hbsmith_real_device set is_occupied=0 where id <> 1;
    ```
- 라미엘 배포: `BRANCH_WS_SCRCPY=DEV-16083 ./provisioning.py on-premise`
- 크롬 브라우저 실행
- 개발자 도구 --> console
- iOS 연결
- 로그 확인

### Screenshots (if appropriate)

- AS-IS:
    - 상단 중앙 UI: 알 수 없는 오류라고 나옴
    - 로그가 3회 뜸 (중복 로깅으로 인함. 실제 실행 회수는 1회)
![image](https://user-images.githubusercontent.com/12525941/187117226-10918f85-3c1f-4921-9ae0-1fe6208c3cbc.png)

- TO-BE
    - 상단 중앙 UI: 이미 사용 중인 장비
    - 로그 1회
![image](https://user-images.githubusercontent.com/12525941/187117324-808b62ed-d724-4394-891e-c5e2ebc8e9dd.png)

