### PR TITLE
DEV-16317 [라미엘] 초기화 실패 이슈- WDA 죽을 때 동작 이상

### DIFF
--- a/src/server/mw/MjpegProxyFactory.ts
+++ b/src/server/mw/MjpegProxyFactory.ts
@@ -26,11 +26,11 @@ export class MjpegProxyFactory {
         const port = wda.mjpegPort;
         const url = `http://127.0.0.1:${port}`;
         const proxy = new MjpegProxy(url);
+        /* TODO: HBsmith
         proxy.on('streamstop', (): void => {
-            // TODO: HBsmith
-            // wda.release();
-            //
+            wda.release();
         });
+        */
         proxy.on('error', (data: { msg: Error; url: string }): void => {
             console.error('msg: ' + data.msg);
             console.error('url: ' + data.url);

--- a/src/server/mw/MjpegProxyFactory.ts
+++ b/src/server/mw/MjpegProxyFactory.ts
@@ -27,7 +27,9 @@ export class MjpegProxyFactory {
         const url = `http://127.0.0.1:${port}`;
         const proxy = new MjpegProxy(url);
         proxy.on('streamstop', (): void => {
-            wda.release();
+            // TODO: HBsmith
+            // wda.release();
+            //
         });
         proxy.on('error', (data: { msg: Error; url: string }): void => {
             console.error('msg: ' + data.msg);


### PR DESCRIPTION
### What is this PR for?
- 이중 wda.release() 동작 제거
- 초기화 실패에 영향을 미치는 이슈는 아니나, 버그는 맞기에 PR 작성

### How should this be tested?
- ramiel 저장소로 배포: `./provisioning.py on-premise`
- ios 장비 접속
- 브라우저로 장비 접속
- xcodebuild 프로세스 kill: `kill -9 $(ps -ef |grep xcodebuild | grep -v grep | awk '{print $2}')`
- filelock 로그가 뜨지 말아야 함

### Screenshots (if appropriate)

![image-20221108-021752](https://user-images.githubusercontent.com/12525941/200462293-b9867078-7614-4688-a3df-c15f393f84db.png)

