### PR TITLE
DEV-16805 [라미엘] sentry ramiel_device_type 출력 이상

### DIFF
--- a/src/server/appl-device/mw/WebDriverAgentProxy.ts
+++ b/src/server/appl-device/mw/WebDriverAgentProxy.ts
@@ -111,7 +111,7 @@ export class WebDriverAgentProxy extends Mw {
                 this.ws.close(4900, e.message);
                 this.logger.error(e);
                 Sentry.captureException(e, (scope) => {
-                    scope.setTag('ramiel_device_type', 'Android');
+                    scope.setTag('ramiel_device_type', 'iOS');
                     scope.setTag('ramiel_device_id', udid);
                     scope.setTag('ramiel_message', e.ramiel_message || mm);
                     if (e.ramiel_contexts) {

--- a/src/server/appl-device/mw/WebDriverAgentProxy.ts
+++ b/src/server/appl-device/mw/WebDriverAgentProxy.ts
@@ -262,8 +262,7 @@ export class WebDriverAgentProxy extends Mw {
                     e.ramiel_message = e.message = 'undefined response in error';
                 } else if (409 === status) {
                     const userAgent = 'user-agent' in e.response.data ? e.response.data['user-agent'] : '';
-                    e.message = '사용 중인 장비입니다';
-                    e.ramiel_message = 'DEVICE_IS_OCCUPIED';
+                    e.ramiel_message = e.message = '사용 중인 장비입니다';
                     if (userAgent) e.message += ` (${userAgent})`;
 
                     e.ramiel_contexts = {


### PR DESCRIPTION
### What is this PR for?
- 로그 이상 수정

### How should this be tested?
- OP 환경에서 확인 패치 이후 확인
- sentry --> discovery --> saved queries --> udid가 ios 형식이나 ramiel_device_type 값이 Android인 것이 없어야 함
