### PR TITLE
DEV-16543 [라미엘] heartbeat 기능 구현

### DIFF
--- a/src/app/applDevice/client/StreamClient.ts
+++ b/src/app/applDevice/client/StreamClient.ts
@@ -109,6 +109,7 @@ export abstract class StreamClient<T extends ParamsStream> extends BaseClient<T,
     // TODO: HBsmith
     protected appKey?: string;
     protected userAgent?: string;
+    private heartbeatTimer: NodeJS.Timeout;
     //
 
     protected constructor(params: ParsedUrlQuery | T) {
@@ -119,6 +120,9 @@ export abstract class StreamClient<T extends ParamsStream> extends BaseClient<T,
         // TODO: HBsmith
         this.appKey = 'app_key' in params ? params['app_key']?.toString() : undefined;
         this.userAgent = 'user-agent' in params ? params['user-agent']?.toString() : undefined;
+        this.heartbeatTimer = setInterval(() => {
+            // return this.wdaProxy.sendHeartbeat();
+        }, 120 * 1000);
         //
 
         const controlHeaderView = document.createElement('div');
@@ -265,6 +269,9 @@ export abstract class StreamClient<T extends ParamsStream> extends BaseClient<T,
         }
         this.wdaProxy.stop();
         this.player?.stop();
+        // TODO: HBsmith
+        clearInterval(this.heartbeatTimer);
+        //
     }
 
     public setWdaStatusNotification(status: WdaStatus): void {

--- a/src/app/applDevice/client/StreamClient.ts
+++ b/src/app/applDevice/client/StreamClient.ts
@@ -109,7 +109,7 @@ export abstract class StreamClient<T extends ParamsStream> extends BaseClient<T,
     // TODO: HBsmith
     protected appKey?: string;
     protected userAgent?: string;
-    private heartbeatTimer: NodeJS.Timeout;
+    private readonly heartbeatTimer: NodeJS.Timeout;
     //
 
     protected constructor(params: ParsedUrlQuery | T) {

--- a/src/app/applDevice/client/StreamClient.ts
+++ b/src/app/applDevice/client/StreamClient.ts
@@ -121,7 +121,7 @@ export abstract class StreamClient<T extends ParamsStream> extends BaseClient<T,
         this.appKey = 'app_key' in params ? params['app_key']?.toString() : undefined;
         this.userAgent = 'user-agent' in params ? params['user-agent']?.toString() : undefined;
         this.heartbeatTimer = setInterval(() => {
-            // return this.wdaProxy.sendHeartbeat();
+            return this.wdaProxy.sendHeartbeat();
         }, 120 * 1000);
         //
 

--- a/src/app/applDevice/client/StreamClient.ts
+++ b/src/app/applDevice/client/StreamClient.ts
@@ -199,12 +199,17 @@ export abstract class StreamClient<T extends ParamsStream> extends BaseClient<T,
         switch (data.status) {
             case WdaStatus.STARTING:
             case WdaStatus.STARTED:
-            case WdaStatus.STOPPED:
-            case WdaStatus.ERROR:
             case WdaStatus.IN_ACTION:
             case WdaStatus.END_ACTION:
                 this.logWdaStatus(message);
                 break;
+            // TODO: HBsmith
+            case WdaStatus.STOPPED:
+            case WdaStatus.ERROR:
+                this.player?.stop();
+                this.logWdaStatus(message);
+                break;
+            //
             case WdaStatus.SET_UP_DEVICE_INFO:
                 if (data.text) {
                     this.deviceName = data.text;

--- a/src/app/applDevice/client/StreamClient.ts
+++ b/src/app/applDevice/client/StreamClient.ts
@@ -122,7 +122,7 @@ export abstract class StreamClient<T extends ParamsStream> extends BaseClient<T,
         this.userAgent = 'user-agent' in params ? params['user-agent']?.toString() : undefined;
         this.heartbeatTimer = setInterval(() => {
             return this.wdaProxy.sendHeartbeat();
-        }, 120 * 1000);
+        }, 60 * 1000);
         //
 
         const controlHeaderView = document.createElement('div');

--- a/src/app/applDevice/client/WdaProxyClient.ts
+++ b/src/app/applDevice/client/WdaProxyClient.ts
@@ -306,6 +306,20 @@ export class WdaProxyClient
         return this.sendMessage(message);
     }
 
+    // TODO: HBsmith
+    public async sendHeartbeat(): Promise<Message> {
+        if (!this.hasSession) {
+            throw Error('No session');
+        }
+        const message: Message = {
+            id: this.getNextId(),
+            type: ControlCenterCommand.HEARTBEAT,
+            data: {},
+        };
+        return this.sendMessage(message);
+    }
+    //
+
     protected supportMultiplexing(): boolean {
         return true;
     }

--- a/src/app/controlMessage/CommandControlMessage.ts
+++ b/src/app/controlMessage/CommandControlMessage.ts
@@ -221,6 +221,15 @@ export class CommandControlMessage extends ControlMessage {
         event.buffer = buffer;
         return event;
     }
+
+    public static createHeartBeatCommand(): CommandControlMessage {
+        const event = new CommandControlMessage(ControlMessage.TYPE_HEARTBEAT);
+        let offset = 0;
+        const buffer = Buffer.alloc(1);
+        offset = buffer.writeInt8(event.type, offset);
+        event.buffer = buffer;
+        return event;
+    }
     //
 
     private buffer?: Buffer;

--- a/src/app/controlMessage/CommandControlMessage.ts
+++ b/src/app/controlMessage/CommandControlMessage.ts
@@ -196,10 +196,9 @@ export class CommandControlMessage extends ControlMessage {
     // TODO: HBsmith
     public static createAdbControlCommand(value: number): CommandControlMessage {
         const event = new CommandControlMessage(ControlMessage.TYPE_ADB_CONTROL);
-        let offset = 0;
         const buffer = new Buffer(1 + 1);
-        offset += buffer.writeUInt8(event.type, offset);
-        buffer.writeUInt8(value, offset);
+        buffer.writeUInt8(event.type, 0);
+        buffer.writeUInt8(value, 1);
         event.buffer = buffer;
         return event;
     }
@@ -222,11 +221,11 @@ export class CommandControlMessage extends ControlMessage {
         return event;
     }
 
-    public static createHeartBeatCommand(): CommandControlMessage {
+    public static createHeartbeatCommand(): CommandControlMessage {
         const event = new CommandControlMessage(ControlMessage.TYPE_HEARTBEAT);
-        let offset = 0;
-        const buffer = Buffer.alloc(1);
-        offset = buffer.writeInt8(event.type, offset);
+        const buffer = new Buffer(1 + 1);
+        buffer.writeUInt8(event.type, 0);
+        buffer.writeUInt8(0, 1);
         event.buffer = buffer;
         return event;
     }

--- a/src/app/controlMessage/ControlMessage.ts
+++ b/src/app/controlMessage/ControlMessage.ts
@@ -22,6 +22,7 @@ export class ControlMessage {
     public static TYPE_ADB_CONTROL_SWIPE_UP = 0;
     public static TYPE_ADB_CONTROL_SWIPE_DOWN = 1;
     public static TYPE_ADB_INSTALL_APK = 2;
+    public static TYPE_HEARTBEAT = 3;
     //
 
     constructor(readonly type: number) {}

--- a/src/app/controlMessage/ControlMessage.ts
+++ b/src/app/controlMessage/ControlMessage.ts
@@ -22,7 +22,8 @@ export class ControlMessage {
     public static TYPE_ADB_CONTROL_SWIPE_UP = 0;
     public static TYPE_ADB_CONTROL_SWIPE_DOWN = 1;
     public static TYPE_ADB_INSTALL_APK = 2;
-    public static TYPE_HEARTBEAT = 3;
+
+    public static TYPE_HEARTBEAT = 201;
     //
 
     constructor(readonly type: number) {}

--- a/src/app/googDevice/client/StreamClientScrcpy.ts
+++ b/src/app/googDevice/client/StreamClientScrcpy.ts
@@ -169,7 +169,7 @@ export class StreamClientScrcpy
 
         this.heartbeatTimer = setInterval(() => {
             this.sendMessage(CommandControlMessage.createHeartbeatCommand());
-        }, 120 * 1000);
+        }, 60 * 1000);
         //
     }
 

--- a/src/app/googDevice/client/StreamClientScrcpy.ts
+++ b/src/app/googDevice/client/StreamClientScrcpy.ts
@@ -65,6 +65,9 @@ export class StreamClientScrcpy
     private filePushHandler?: FilePushHandler;
     private fitToScreen?: boolean;
     private readonly streamReceiver: StreamReceiverScrcpy;
+    // TODO: HBsmith
+    private readonly heartbeatTimer: NodeJS.Timeout;
+    //
 
     public static registerPlayer(playerClass: PlayerClass): void {
         if (playerClass.isSupported()) {
@@ -163,6 +166,10 @@ export class StreamClientScrcpy
         } finally {
             this.setBodyClass('stream');
         }
+
+        this.heartbeatTimer = setInterval(() => {
+            this.sendMessage(CommandControlMessage.createHeartBeatCommand());
+        }, 120 * 1000);
         //
     }
 
@@ -217,6 +224,7 @@ export class StreamClientScrcpy
         if (statusText) {
             statusText.textContent = ev.reason;
         }
+        clearInterval(this.heartbeatTimer);
     };
 
     public onEventMessage = (ev: MessageEvent): void => {

--- a/src/app/googDevice/client/StreamClientScrcpy.ts
+++ b/src/app/googDevice/client/StreamClientScrcpy.ts
@@ -168,7 +168,7 @@ export class StreamClientScrcpy
         }
 
         this.heartbeatTimer = setInterval(() => {
-            this.sendMessage(CommandControlMessage.createHeartBeatCommand());
+            this.sendMessage(CommandControlMessage.createHeartbeatCommand());
         }, 120 * 1000);
         //
     }

--- a/src/common/ControlCenterCommand.ts
+++ b/src/common/ControlCenterCommand.ts
@@ -7,6 +7,7 @@ export class ControlCenterCommand {
     public static CONFIGURE_STREAM = 'configure_stream';
     public static RUN_WDA = 'run-wda';
     public static REQUEST_WDA = 'request-wda';
+    public static HEARTBEAT = 'heartbeat';  // TODO: HBsmith
 
     private id = -1;
     private type = '';
@@ -47,6 +48,7 @@ export class ControlCenterCommand {
             case this.UPDATE_INTERFACES:
             case this.CONFIGURE_STREAM:
             case this.RUN_WDA:
+            case this.HEARTBEAT:    // TODO: HBsmith
                 return command;
             default:
                 throw new Error(`Unknown command "${body.command}"`);

--- a/src/server/appl-device/mw/WebDriverAgentProxy.ts
+++ b/src/server/appl-device/mw/WebDriverAgentProxy.ts
@@ -51,7 +51,7 @@ export class WebDriverAgentProxy extends Mw {
         this.logger = new Logger(udid, 'iOS');
         this.lastHeartbeat = Date.now();
         this.heartbeatTimer = setInterval(() => {
-            if (Date.now() - this.lastHeartbeat < 300 * 1000) {
+            if (Date.now() - this.lastHeartbeat < 120 * 1000) {
                 return;
             }
             if (this.wda) {

--- a/src/server/appl-device/mw/WebDriverAgentProxy.ts
+++ b/src/server/appl-device/mw/WebDriverAgentProxy.ts
@@ -22,6 +22,8 @@ export class WebDriverAgentProxy extends Mw {
     private userAgent: string;
     private apiSessionCreated: boolean;
     private logger: Logger;
+    private lastHeartbeat: number;
+    private heartbeatTimer: NodeJS.Timeout;
     //
 
     public static processChannel(ws: Multiplexer, code: string, data: ArrayBuffer): Mw | undefined {
@@ -47,6 +49,26 @@ export class WebDriverAgentProxy extends Mw {
         this.userAgent = '';
         this.apiSessionCreated = false;
         this.logger = new Logger(udid, 'iOS');
+        this.lastHeartbeat = Date.now();
+        this.heartbeatTimer = setInterval(() => {
+            if (Date.now() - this.lastHeartbeat < 300 * 1000) {
+                return;
+            }
+            if (this.wda) {
+                const message: MessageRunWdaResponse = {
+                    id: -1,
+                    type: 'run-wda',
+                    data: {
+                        udid,
+                        status: WdaStatus.ERROR,
+                        code: -1,
+                        text: 'Heartbeat timeout',
+                    },
+                };
+                this.sendMessage(message);
+            }
+            this.ws.close(4900, 'Heartbeat timeout');
+        }, 1000);
         //
     }
 
@@ -69,7 +91,7 @@ export class WebDriverAgentProxy extends Mw {
                         id,
                         type: 'run-wda',
                         data: {
-                            udid: udid,
+                            udid,
                             status: WdaStatus.STARTED,
                             code: -1,
                             text: 'WDA already started',
@@ -191,6 +213,11 @@ export class WebDriverAgentProxy extends Mw {
             case ControlCenterCommand.REQUEST_WDA:
                 this.requestWda(command);
                 break;
+            // TODO: HBsmith
+            case ControlCenterCommand.HEARTBEAT:
+                this.lastHeartbeat = Date.now();
+                break;
+            //
             default:
                 throw new Error(`Unsupported command: "${type}"`);
         }
@@ -201,6 +228,8 @@ export class WebDriverAgentProxy extends Mw {
         if (!this.apiSessionCreated || !this.udid) {
             return;
         }
+
+        clearInterval(this.heartbeatTimer);
 
         new Promise((resolve) => setTimeout(resolve, 3000))
             .then(() => {

--- a/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
+++ b/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
@@ -30,7 +30,7 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
         super(ws);
         this.logger = new Logger(udid, 'Android');
         this.heartbeatTimer = setInterval(() => {
-            if (Date.now() - this.lastHeartbeat < 300 * 1000) {
+            if (Date.now() - this.lastHeartbeat < 120 * 1000) {
                 return;
             }
             this.ws.close(4900, 'Heartbeat timeout');

--- a/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
+++ b/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
@@ -315,10 +315,9 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
                             });
                         return;
                     }
-                    case ControlMessage.TYPE_HEARTBEAT:
-                        this.lastHeartbeat = Date.now();
-                        return;
                 }
+            } else if (type === ControlMessage.TYPE_HEARTBEAT) {
+                this.lastHeartbeat = Date.now();
             }
         } catch (e) {
             this.logger.error(e);


### PR DESCRIPTION
### What is this PR for?
- heartbeat 기능 구현: 클라단 신호가 일정 시간동안 없을 경우 강제로 연결을 종료하는 기능
- 서버단 heartbeat 만료 기간: 2분
- 클라단 heartbeat 갱신 주기: 1분

### How should this be tested?
- db, sachiel master 배포
- 라미엘 배포: `BRANCH_WS_SCRCPY=DEV-16543 ./provisioning.py on-premise`
- 공통 테스트: iOS/Android 세션 열고 10분 대기 --> 접속 유지 및 제어 정상 확인
- 코드 변조 후 타임아웃 테스트:
    - iOS
        - `StreamClient.ts` 수정 후 서비스 재시작 `launchctl stop ramiel.ws-scrcpy-ios.hbsmith.io` --> 브라우저로 접속 후 2분 대기
            ```
            this.heartbeatTimer = setInterval(() => {
                 return this.wdaProxy.sendHeartbeat();
            }, 60 * 1000);
            ```
    - Android: `TBD` 수정 후 서비스 재시작 `launchctl stop ramiel.ws-scrcpy.hbsmith.io` --> 브라우저로 접속 후 2분 대기
            ```
            this.heartbeatTimer = setInterval(() => {
                // this.sendMessage(CommandControlMessage.createHeartBeatCommand());
            }, 60 * 1000);
            ```
- 타임아웃 발생 후 다른 세션 열 경우 정상 접속 확인

### Screenshots (if appropriate)

- 타임아웃 발생 후 다른 세션 열 경우 정상 접속 확인
- iOS
![스크린샷 2022-12-13 오후 12 17 13](https://user-images.githubusercontent.com/12525941/207218722-3a4d182e-fac7-46f6-b636-b5736db9d736.png)

- Android
![image](https://user-images.githubusercontent.com/12525941/207223269-f76bd6ec-c586-4e5f-8bed-13b5534a08f1.png)
