### PR TITLE
DEV-15945 [라미엘] ws-scrcpy로의 OAUTH2.0 접근 허용

### DIFF
--- a/src/server/services/HttpServer.ts
+++ b/src/server/services/HttpServer.ts
@@ -87,8 +87,13 @@ export class HttpServer extends TypedEmitter<HttpServerEvents> implements Servic
                 const accessToken = req.query['access-token'];
 
                 if (accessToken) {
+                    const udid = req.query['udid'];
+                    if (!udid) {
+                        res.status(401).send('UNAUTHORIZED');
+                        return;
+                    }
                     try {
-                        await axios.get(`${Config.getInstance().getRamielApiServerEndpoint()}/users/`, {
+                        await axios.get(`${Config.getInstance().getRamielApiServerEndpoint()}/real-devices/${udid}/`, {
                             headers: { 'Authorization': `Bearer ${accessToken}` },
                         });
                     } catch (e) {

--- a/src/server/services/HttpServer.ts
+++ b/src/server/services/HttpServer.ts
@@ -9,6 +9,7 @@ import { TypedEmitter } from '../../common/TypedEmitter';
 // TODO: HBsmith
 import * as Sentry from '@sentry/node';
 import * as Tracing from '@sentry/tracing';
+import axios from "axios";
 //
 
 const DEFAULT_STATIC_DIR = path.join(__dirname, './public');
@@ -75,7 +76,7 @@ export class HttpServer extends TypedEmitter<HttpServerEvents> implements Servic
     }
 
     // TODO: HBsmith
-    public CheckPermission(req: express.Request, res: express.Response, next: express.NextFunction): void {
+    public async CheckPermission(req: express.Request, res: express.Response, next: express.NextFunction) {
         if (req.hostname === 'localhost') {
             console.log(Utils.getTimeISOString(), 'Checking permission has been bypassed: host is', req.hostname);
         } else if (req.url === '/') {
@@ -83,40 +84,43 @@ export class HttpServer extends TypedEmitter<HttpServerEvents> implements Servic
             return;
         } else if (Object.keys(req.query).length != 0) {
             try {
-                const expireTimestampIn = 300;
+                const accessToken = req.query['access-token'];
 
-                const api = req.query['GET'];
-                const appKey = req.query.hasOwnProperty('app_key') ? req.query['app_key'] : null;
-                const timestamp = Number(req.query['timestamp']);
-                const userAgent = req.query['user-agent'];
-                const signature = req.query['signature'];
-
-                const curTimestamp = Utils.getTimestamp();
-                const td = curTimestamp - timestamp;
-                if (td > expireTimestampIn) {
-                    res.status(400).send('timestamp');
-                    return;
-                }
-
-                let pp;
-                if (appKey) {
-                    pp = {
-                        GET: api,
-                        app_key: appKey,
-                        timestamp: timestamp,
-                        'user-agent': userAgent,
-                    };
+                if (accessToken) {
+                    try {
+                        await axios.get(`${Config.getInstance().getRamielApiServerEndpoint()}/users/`, {
+                            headers: { 'Authorization': `Bearer ${accessToken}` },
+                        });
+                    } catch (e) {
+                        res.status(401).send(e.response && e.response.status || 'UNAUTHORIZED');
+                        return;
+                    }
                 } else {
-                    pp = {
-                        GET: api,
-                        timestamp: timestamp,
-                        'user-agent': userAgent,
-                    };
-                }
-                const serverSignature = Utils.getSignature(pp, timestamp);
-                if (serverSignature != signature) {
-                    res.status(400).send('signature');
-                    return;
+                    const api = req.query['GET'];
+                    const appKey = req.query['app_key'];
+                    const userAgent = req.query['user-agent'];
+                    const timestamp = Number(req.query['timestamp']);
+                    const signature = req.query['signature'];
+
+                    if (Utils.getTimestamp() - timestamp > 300) {
+                        res.status(400).send('timestamp');
+                        return;
+                    }
+
+                    const pp = {
+                            GET: api,
+                            timestamp: timestamp,
+                            'user-agent': userAgent,
+                        };
+                    if (appKey) {
+                        // @ts-ignore
+                        pp['app_key'] = appKey;
+                    }
+                    const serverSignature = Utils.getSignature(pp, timestamp);
+                    if (serverSignature != signature) {
+                        res.status(400).send('signature');
+                        return;
+                    }
                 }
             } catch (e) {
                 res.status(400).send('BAD REQUEST');


### PR DESCRIPTION
### What is this PR for?
- OAUTH2.0 인증 지원
- 참조
    - https://github.com/HardBoiledSmith/ws-scrcpy/pull/130
    - https://github.com/HardBoiledSmith/sachiel/pull/1269

### How should this be tested?
- 배포
    - db: master
    - sachiel: `BRANCH=DEV-15945 vagrant up`
    - ramiel: : `BRANCH_WS_SCRCPY=DEV-15945 provisioning.py on-premise`

- 다음 URL로 접속 확인
    - http://<HOST>:28500/?access-token=`<ACCESS_TOKEN>`&udid=`<디비에 있는 임의의 UDID>`#!action=stream-mjpeg&player=mjpeghttp&udid=00008020-00094C693A33002E
    - HOST 확인 빙법: `vim /var/log/ramiel/ws-scrcpy.stdout.log` ---> 표시된 것 중 `localhost`가 아닌 것 사용
![image](https://user-images.githubusercontent.com/12525941/209126002-dca3318c-3e49-406e-90a3-28cc67968708.png)

- 1차: 장비에 팀 설정 없이 시도 시 Forbidden 확인
- 2차: 장비에 팀 설정 후 연결 되는지 확인
    - 장비에 팀 일괄 할당
    ```sql
    update hbsmith.hbsmith_real_device
    set team_id=1
    where id<>1;
    ```
- 앱콘솔 띄우고 로그인 --> 개발자 도구 --> 임의의 api에서 access token 확인
    - ![image](https://user-images.githubusercontent.com/12525941/209126485-65018202-206c-481a-9fc2-34e3b4fbbdeb.png)

### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/12525941/209126855-225885d9-9951-4bd6-ace6-72e98ad36aba.png)

![image](https://user-images.githubusercontent.com/12525941/209127017-b648c0cc-bd09-4a9e-96bd-f942382261f9.png)

