### PR TITLE
DEV-18306 [ramiel] Error: ENOENT: no such file or directory, scandir '/tmp/ramiel_file_lock'

### DIFF
--- a/src/server/Utils.ts
+++ b/src/server/Utils.ts
@@ -134,6 +134,10 @@ export class Utils {
     }
 
     public static async initFileLock(): Promise<void> {
+        try {
+            fs.mkdirSync(Utils.PathToFileLock);
+        } catch (e) {}
+
         const pp = `${Utils.PathToFileLock}/${Config.getInstance().getServerPort()}`;
         try {
             if (fs.existsSync(pp)) {
@@ -141,7 +145,7 @@ export class Utils {
             }
             fs.mkdirSync(pp);
         } catch (e) {
-            console.log(e);
+            console.error(e);
         }
     }
 

--- a/src/server/Utils.ts
+++ b/src/server/Utils.ts
@@ -101,7 +101,7 @@ export class Utils {
     }
 
     private static checkExpiredFileLock(file: string): void {
-        const pp = `${Utils.PathToFileLock}/${file}`;
+        const pp = `${Utils.PathToFileLock}/${Config.getInstance().getServerPort()}/${file}`;
         if (!fs.existsSync(pp)) {
             return;
         }
@@ -125,20 +125,21 @@ export class Utils {
     }
 
     private static fileLock(file: string): void {
-        const fd = fs.openSync(`${Utils.PathToFileLock}/${file}`, 'wx');
+        const fd = fs.openSync(`${Utils.PathToFileLock}/${Config.getInstance().getServerPort()}/${file}`, 'wx');
         fs.closeSync(fd);
     }
 
     public static fileUnlock(file: string): void {
-        fs.unlinkSync(`${Utils.PathToFileLock}/${file}`);
+        fs.unlinkSync(`${Utils.PathToFileLock}/${Config.getInstance().getServerPort()}/${file}`);
     }
 
     public static async initFileLock(): Promise<void> {
+        const pp = `${Utils.PathToFileLock}/${Config.getInstance().getServerPort()}`;
         try {
-            if (fs.existsSync(Utils.PathToFileLock)) {
-                fs.rmdirSync(Utils.PathToFileLock, { recursive: true });
+            if (fs.existsSync(pp)) {
+                fs.rmdirSync(pp, { recursive: true });
             }
-            fs.mkdirSync(Utils.PathToFileLock);
+            fs.mkdirSync(pp);
         } catch (e) {
             console.log(e);
         }


### PR DESCRIPTION
### What is this PR for?
- 파일락 경로에 서버 포트를 추가
- 목적
    - 두 개의 ws-scrcpy 프로세스 (android, ios)가 동일한 파일락 경로 사용 
    - 사례) iOS 접속 중 --> ws-scrcpy android 서비스 재시작 --> ws-scrcpy ios의 파일락 초기화 됨 --> iOS 접속에 이슈 발생

### How should this be tested?
- 배포
    - sachel, db: master
    - ramiel: `BRANCH_WS_SCRCPY=DEV-18306 ./provisioning.py on-premise`
- 다음 환경 설정 후 iOS 정상 연결 확인
    1. `/tmp/ramiel_file_lock` 폴더 삭제 --> ws-scrcpy 서비스 재시작 `launchctl stop ramiel.ws-scrcpy-ios.hbsmith.io.plist` --> iOS 정상 접속 확인
    1. `/tmp/ramiel_file_lock/28100` 폴더 삭제 --> ws-scrcpy 서비스 재시작 `launchctl stop ramiel.ws-scrcpy-ios.hbsmith.io.plist` --> iOS 정상 접속 확인
    1. `/tmp/ramiel_file_lock/28100/*` 모든 파일 --> ws-scrcpy 서비스 재시작 `launchctl stop ramiel.ws-scrcpy-ios.hbsmith.io.plist` --> iOS 정상 접속 확인


