### PR TITLE
DEV-18710-1 [라미엘] 장비 별 팀 할당 멀티 지정 가능 (보완 #1)

### DIFF
--- a/src/server/services/HttpServer.ts
+++ b/src/server/services/HttpServer.ts
@@ -95,7 +95,8 @@ export class HttpServer extends TypedEmitter<HttpServerEvents> implements Servic
                     }
                     try {
                         await axios.get(`${Config.getInstance().getRamielApiServerEndpoint()}/real-devices/${udid}/`, {
-                            headers: { Authorization: `Bearer ${accessToken}`, team_name: teamName },
+                            headers: { Authorization: `Bearer ${accessToken}` },
+                            params: { team_name: teamName }
                         });
                     } catch (e) {
                         res.status(401).send((e.response && e.response.status) || 'UNAUTHORIZED');


### PR DESCRIPTION
### What is this PR for?
- team_name query param 누락으로 QA 환경에서 NotFound가 발생하는 문제 해결시도
