### PR TITLE
DEV-18524 [라미엘] TypeError: Cannot read properties of undefined (reading 'status')

### DIFF
--- a/src/server/appl-device/services/WDARunner.ts
+++ b/src/server/appl-device/services/WDARunner.ts
@@ -386,7 +386,7 @@ export class WdaRunner extends TypedEmitter<WdaRunnerEvents> {
             return rr.data;
         } catch (error) {
             let msg;
-            if ('response' in error) {
+            if (error.response && error.response.status) {
                 msg = `[${WdaRunner.TAG}] Cannot retrieve the device ${udid}. resp code: ${error.response.status}`;
             } else {
                 msg = `[${WdaRunner.TAG}] ${error.message}`;

--- a/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
+++ b/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
@@ -291,6 +291,8 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
                                 return device.runShellCommandAdbKit('wm size | tail -1');
                             })
                             .then((rr) => {
+                                if (!rr) throw Error('Failed to get screen size');
+
                                 let [, ww, hh] = rr.match(/(\d+)x(\d+)/);
                                 if (isLandscape) {
                                     [ww, hh] = [hh, ww];


### PR DESCRIPTION
### What is this PR for?

- 다음 에러 해결:
    - case1:  `TypeError: Cannot read properties of undefined (reading 'status')`
    - case2: `object null is not iterable (cannot read property Symbol(Symbol.iterator)`
- 원인: 
    - case1:
        - ts에서 형태: `msg = `[${WdaRunner.TAG}] Cannot retrieve the device ${udid}. resp code: ${error.response.status}`;`
        - js에서 형태: `'{snip}  Cannot retrieve the device "+e+". resp code: "+f.response.status:"["+t.TAG+"] "+f.message,console.error(u.Utils.getTimeISOString(),e,p),f;c {snip}`
        - concat 형태가 되어 undefined를 이어 붙이게 시도
    - case2: 안드로이드 wm size에서 잘못된 값 리턴

### How should this be tested?
- OP sentry에서 `TypeError: Cannot read properties of undefined (reading 'status')` 발생 안 함