### PR TITLE
DEV-18973 [라미엘] ws-scrcpy 시작 시 항상 장비를 사용할 수 있는 상태로 전환

### DIFF
--- a/src/server/appl-device/mw/WebDriverAgentProxy.ts
+++ b/src/server/appl-device/mw/WebDriverAgentProxy.ts
@@ -304,6 +304,44 @@ export class WebDriverAgentProxy extends Mw {
             });
     }
 
+    public static deleteSession(udid: string, userAgent: string, logger: Logger | null = null) {
+        const host = Config.getInstance().getRamielApiServerEndpoint();
+        const api = `/real-devices/${udid}/control/`;
+        const hh = { 'Content-Type': 'application/x-www-form-urlencoded; charset=utf8' };
+        const tt = Utils.getTimestamp();
+        const pp = {
+            DELETE: api,
+            timestamp: tt,
+            'user-agent': userAgent,
+        };
+        const data = qs.stringify({
+            DELETE: api,
+            timestamp: tt,
+            'user-agent': userAgent,
+            signature: Utils.getSignature(pp),
+        });
+        const url = `${host}${api}`;
+        const tag = WebDriverAgentProxy.TAG;
+
+        axios
+            .delete(url, {
+                headers: hh,
+                data: data,
+            })
+            .then((rr) => {
+                if (logger) logger.info(`[${tag}] success to delete session. resp code: ${rr.status}`);
+            })
+            .catch((e) => {
+                let status;
+                try {
+                    status = e.response && e.response.status ? e.response.status : 'unknown_iOS';
+                } catch {
+                    status = e.toString();
+                }
+                console.error(Utils.getTimeISOString(), `[${tag}] failed to delete a session: ${status}`);
+            });
+    }
+
     private apiDeleteSession() {
         if (!this.udid) return;
 

--- a/src/server/services/HttpServer.ts
+++ b/src/server/services/HttpServer.ts
@@ -95,7 +95,7 @@ export class HttpServer extends TypedEmitter<HttpServerEvents> implements Servic
                     try {
                         await axios.get(`${Config.getInstance().getRamielApiServerEndpoint()}/real-devices/${udid}/`, {
                             headers: { Authorization: `Bearer ${accessToken}` },
-                            params: { team_name: teamName }
+                            params: { team_name: teamName },
                         });
                     } catch (e) {
                         res.status(401).send((e.response && e.response.status) || 'UNAUTHORIZED');
@@ -140,6 +140,7 @@ export class HttpServer extends TypedEmitter<HttpServerEvents> implements Servic
 
     public async start(): Promise<void> {
         // TODO: HBsmith
+        await Utils.initDevices();
         await Utils.initFileLock();
 
         const app = express();


### PR DESCRIPTION
### What is this PR for?
- ios/android ws-scrcpy 시작 시 각 옵션에 맞는 장비들의 점유 상태 해제

### How should this be tested?
- 라미엘 배포: `BRANCH_WS_SCRCPY=DEV-18973 ./provisioning.py on-premise`
-  android 테스트: android 접속 (`localhost:28500/...`) --> 장비 연결한 상태에서 서버 재시작: launchctl stop ramiel.ws-scrcpy.hbsmith.io --> 5분 대기 --> 동일 장비 접속 --> 접속 확인
-  iOS 테스트: android 접속 (`localhost:28100/...`) --> 장비 연결한 상태에서 서버 재시작: launchctl stop ramiel.ws-scrcpy-ios.hbsmith.io --> 5분 대기 --> 동일 장비 접속 --> 접속 확인
