### PR TITLE
DEV-18650 [라미엘] NoSuchDriverError: Session does not exist

### DIFF
--- a/src/server/appl-device/mw/WebDriverAgentProxy.ts
+++ b/src/server/appl-device/mw/WebDriverAgentProxy.ts
@@ -221,13 +221,12 @@ export class WebDriverAgentProxy extends Mw {
 
         clearInterval(this.heartbeatTimer);
 
-        new Promise((resolve) => setTimeout(resolve, 3000))
-            .then(() => {
-                return this.wda?.tearDownTest().catch((e) => {
-                    this.logger.error(e);
-                });
-            })
-            .finally(() => {
+        new Promise((resolve) => setTimeout(resolve, 3000)).then(async () => {
+            try {
+                await this.wda?.tearDownTest();
+            } catch (e) {
+                this.logger.error(e);
+            } finally {
                 super.release();
                 if (this.wda) {
                     this.wda.release();
@@ -236,7 +235,8 @@ export class WebDriverAgentProxy extends Mw {
                 setTimeout(() => {
                     this.apiDeleteSession();
                 }, 3000);
-            });
+            }
+        });
         //
     }
 


### PR DESCRIPTION
### What is this PR for?
- 장비 연결 해제 로직 단순화로 연결 해제 중 발생 가능한 미정의 동작 해결

### How should this be tested?
- 라미엘 배포: `BRANCH_WS_SCRCPY=DEV-18650 ./provisioning.py on-premise`
- 장비 세션 연결 --> 해제 --> 10초 대기 --> 다시 연결 --> 성공
