### PR TITLE
DEV-19182 [라미엘] 안드로이드 sendtext 문제해결시도 #1

### DIFF
--- a/src/app/controlMessage/CommandControlMessage.ts
+++ b/src/app/controlMessage/CommandControlMessage.ts
@@ -229,6 +229,24 @@ export class CommandControlMessage extends ControlMessage {
         event.buffer = buffer;
         return event;
     }
+
+    public static createBardielSetTextCommand(text: string): CommandControlMessage {
+        const event = new CommandControlMessage(ControlMessage.TYPE_BARDIEL_CONTROL);
+        const textBytes: Uint8Array | null = text ? Util.stringToUtf8ByteArray(text) : null;
+        const textLength = textBytes ? textBytes.length : 0;
+        let offset = 0;
+        const buffer = Buffer.alloc(1 + 1 + 4 + textLength);
+        offset = buffer.writeUInt8(event.type, offset);
+        offset = buffer.writeUInt8(ControlMessage.TYPE_BARDIEL_SET_TEXT, offset);
+        offset = buffer.writeInt32BE(textLength, offset);
+        if (textBytes) {
+            textBytes.forEach((byte: number, index: number) => {
+                buffer.writeUInt8(byte, index + offset);
+            });
+        }
+        event.buffer = buffer;
+        return event;
+    }
     //
 
     private buffer?: Buffer;

--- a/src/app/controlMessage/ControlMessage.ts
+++ b/src/app/controlMessage/ControlMessage.ts
@@ -25,6 +25,9 @@ export class ControlMessage {
     public static TYPE_ADB_TERMINATE_APP = 3;
 
     public static TYPE_HEARTBEAT = 201;
+
+    public static TYPE_BARDIEL_CONTROL = 202;
+    public static TYPE_BARDIEL_SET_TEXT = 0;
     //
 
     constructor(readonly type: number) {}

--- a/src/app/googDevice/toolbox/DroidToolBox2.ts
+++ b/src/app/googDevice/toolbox/DroidToolBox2.ts
@@ -140,13 +140,7 @@ export class DroidToolBox2 {
                         if (!text) {
                             break;
                         }
-                        client.sendMessage(CommandControlMessage.createSetClipboardCommand(text));
-
-                        const kk = KeyEvent.KEYCODE_PASTE;
-                        let eventPasteKey = new KeyCodeControlMessage(KeyEvent.ACTION_DOWN, kk, 0, 0);
-                        client.sendMessage(eventPasteKey);
-                        eventPasteKey = new KeyCodeControlMessage(KeyEvent.ACTION_UP, kk, 0, 0);
-                        client.sendMessage(eventPasteKey);
+                        client.sendMessage(CommandControlMessage.createBardielSetTextCommand(text));
                         break;
                     }
                     case 'SwipeUp': {

--- a/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
+++ b/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
@@ -350,8 +350,8 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
                                 .runShellCommandAdbKit(cmd)
                                 .then((rr) => {
                                     if (rr.endsWith(' result=0')) {
-                                        this.logger.info('Failed to set text with bardiel.');
-                                        // TODO: use old copy and paste...
+                                        this.logger.info('Failed to set text with bardiel. use legacy mode.');
+                                        this.sendLegacySetTextCommand(text);
                                         return;
                                     }
                                     this.logger.info(rr);
@@ -361,7 +361,7 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
                                     throw e;
                                 });
                         } else {
-                            this.logger.info('bardiel not enabled. use legacy mode.');
+                            this.logger.info('bardiel is not enabled. use legacy mode.');
                             this.sendLegacySetTextCommand(text);
                         }
                         return;

--- a/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
+++ b/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
@@ -428,7 +428,7 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
             .runShellCommandAdbKit(cmdFindBardiel)
             .then((output) => {
                 if (output.includes('io.hbsmith.bardiel')) {
-                    this.logger.info(`found bardiel installed: ${cmdFindBardiel}`);
+                    this.logger.info(`found bardiel has installed: ${cmdFindBardiel}`);
                     return device.runShellCommandAdbKit(cmdEnableBardiel).then((output) => {
                         this.bardielIsReady = true;
                         this.logger.info(output ? output : `success to set accessibility service: ${cmdEnableBardiel}`);

--- a/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
+++ b/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
@@ -13,7 +13,9 @@ import qs from 'qs';
 import KeyEvent from '../../../app/googDevice/android/KeyEvent';
 import { Multiplexer } from '../../../packages/multiplexer/Multiplexer';
 import { ControlMessage } from '../../../app/controlMessage/ControlMessage';
-import * as Sentry from '@sentry/node'; // TODO: HBsmith
+import * as Sentry from '@sentry/node';
+import { CommandControlMessage } from '../../../app/controlMessage/CommandControlMessage';
+import { KeyCodeControlMessage } from '../../../app/controlMessage/KeyCodeControlMessage';
 //
 
 export class WebsocketProxyOverAdb extends WebsocketProxy {
@@ -24,6 +26,7 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
     private apiSessionCreated = false;
     private logger: Logger;
     private lastHeartbeat: number = Date.now();
+    private bardielIsReady = false;
     private readonly heartbeatTimer: NodeJS.Timeout;
 
     constructor(ws: WS | Multiplexer, udid: string) {
@@ -340,22 +343,28 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
                         const bb = event.data.slice(6);
                         const text = bb.toString();
 
-                        const bardielPkg = 'io.hbsmith.bardiel/.BardielBroadcastReceiver';
-                        const cmd = `am broadcast -n ${bardielPkg} -a set_text -e text '${text}'`;
-                        device
-                            .runShellCommandAdbKit(cmd)
-                            .then((rr) => {
-                                if (rr.endsWith(' result=0')) {
-                                    this.logger.info('Failed to set text with bardiel.');
-                                    // TODO: use old copy and paste...
-                                    return;
-                                }
-                                this.logger.info(rr);
-                            })
-                            .catch((e) => {
-                                e.ramiel_message = 'Failed to set text';
-                                throw e;
-                            });
+                        if (this.bardielIsReady) {
+                            const bardielPkg = 'io.hbsmith.bardiel/.BardielBroadcastReceiver';
+                            const cmd = `am broadcast -n ${bardielPkg} -a set_text -e text '${text}'`;
+                            device
+                                .runShellCommandAdbKit(cmd)
+                                .then((rr) => {
+                                    if (rr.endsWith(' result=0')) {
+                                        this.logger.info('Failed to set text with bardiel.');
+                                        // TODO: use old copy and paste...
+                                        return;
+                                    }
+                                    this.logger.info(rr);
+                                })
+                                .catch((e) => {
+                                    e.ramiel_message = 'Failed to set text';
+                                    throw e;
+                                });
+                        } else {
+                            this.logger.info('bardiel not enabled. use legacy mode.');
+                            this.sendLegacySetTextCommand(text);
+                        }
+                        return;
                     }
                 }
             }
@@ -370,6 +379,18 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
             });
         }
         super.onSocketMessage(event);
+    }
+
+    // TODO: Remove this legacy code after replace all devices to bardiel.
+    private sendLegacySetTextCommand(text: string): void {
+        const cc = CommandControlMessage.createSetClipboardCommand(text);
+        super.onSocketMessageRaw(cc.toBuffer());
+
+        const kk = KeyEvent.KEYCODE_PASTE;
+        let eventPasteKey = new KeyCodeControlMessage(KeyEvent.ACTION_DOWN, kk, 0, 0);
+        super.onSocketMessageRaw(eventPasteKey.toBuffer());
+        eventPasteKey = new KeyCodeControlMessage(KeyEvent.ACTION_UP, kk, 0, 0);
+        super.onSocketMessageRaw(eventPasteKey.toBuffer());
     }
 
     private getDevice(): Device | null {
@@ -394,7 +415,8 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
             return;
         }
 
-        const cmdBardiel =
+        const cmdFindBardiel = 'pm list packages | grep "io.hbsmith.bardiel"';
+        const cmdEnableBardiel =
             'settings put secure enabled_accessibility_services io.hbsmith.bardiel/.BardielAccessibilityService';
         const cmdMenu = `input keyevent ${KeyEvent.KEYCODE_MENU}`;
         const cmdHome = `input keyevent ${KeyEvent.KEYCODE_HOME}`;
@@ -403,9 +425,18 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
         const cmdAppStart = `monkey -p '${this.appKey}' -c android.intent.category.LAUNCHER 1`;
 
         return device
-            .runShellCommandAdbKit(cmdBardiel)
+            .runShellCommandAdbKit(cmdFindBardiel)
             .then((output) => {
-                this.logger.info(output ? output : `success to set accessibility service: ${cmdBardiel}`);
+                if (output.includes('io.hbsmith.bardiel')) {
+                    this.logger.info(`found bardiel installed: ${cmdFindBardiel}`);
+                    return device.runShellCommandAdbKit(cmdEnableBardiel).then((output) => {
+                        this.bardielIsReady = true;
+                        this.logger.info(output ? output : `success to set accessibility service: ${cmdEnableBardiel}`);
+                    });
+                }
+                return;
+            })
+            .then(() => {
                 return device.runShellCommandAdbKit(cmdMenu);
             })
             .then((output) => {
@@ -427,10 +458,15 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
             })
             .then((output) => {
                 this.logger.info(output ? output : `success to stop all of the apps: ${cmdAppStop}`);
-                return device.runShellCommandAdbKit(cmdAppStart);
+                if (this.appKey) {
+                    return device.runShellCommandAdbKit(cmdAppStart).then((output) => {
+                        this.logger.info(output ? output : `success to start the app: ${cmdAppStart}`);
+                    });
+                }
+                return;
             })
-            .then((output) => {
-                this.logger.info(output ? output : `success to start the app: ${cmdAppStart}`);
+            .then(() => {
+                this.logger.info('setup succeeded. ready to test.');
             })
             .catch((e) => {
                 this.logger.error(e);

--- a/src/server/mw/WebsocketProxy.ts
+++ b/src/server/mw/WebsocketProxy.ts
@@ -90,6 +90,13 @@ export class WebsocketProxy extends Mw {
         }
     }
 
+    // TODO: Remove code below after replace all devices to bardiel.
+    protected onSocketMessageRaw(data: WS.Data): void {
+        if (this.remoteSocket) {
+            this.remoteSocket.send(data);
+        }
+    }
+
     public release(): void {
         if (this.released) {
             return;


### PR DESCRIPTION
### What is this PR for?
- [안드로이드 한정] 바르디엘 APK 설치한 경우와 그렇지 않은 경우 모두를 지원하는 코드 추가
-  추가사항
   - SetupTest 초기화 과정에서 불필요한 코드실행 방지 및 예외처리 추가 

### How should this be tested?
- 하기 동영상을 참고하여 bardiel apk 를 설치한 경우와 그렇지 않은 경우 모두를 테스트
   - 바르디엘이 설치되지 않은 경우 send text 시에 로그에 "bardiel not enabled. use legacy mode." 이 뜨도록 함

### Screenshots (if appropriate)
설치하지 않은 경우 

https://github.com/HardBoiledSmith/ws-scrcpy/assets/1650254/37562c83-c5b6-4f21-b8f9-dda681474705

설치한 경우

https://github.com/HardBoiledSmith/ws-scrcpy/assets/1650254/7a865130-cbc4-433e-8a41-a7afc5b271da

