### PR TITLE
DEV-19630 FailError: Failure: ''

### DIFF
--- a/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
+++ b/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
@@ -215,9 +215,9 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
             .catch((e) => {
                 let mm = '';
                 if (e.stack && e.stack.includes('/adbkit/lib/adb/')) {
-                    mm = `[${this.TAG}] Failed to start service: Device is offline - adb is not working.`;
+                    mm = `[${this.TAG}] 장비가 일시적으로 오프라인 상태입니다. 5분 뒤 다시 시도해주세요.`;
                 } else {
-                    const mm = `[${this.TAG}] Failed to start service: ${e.message}`;
+                    const mm = `[${this.TAG}] 서비스 시작 실패: ${e.message}`;
 
                     console.error(Utils.getTimeISOString(), udid, e.stack);
                     Sentry.captureException(e, (scope) => {


### PR DESCRIPTION
### What is this PR for?
- `Failure: ''` 오류 해결
- sachiel에는 is_connected 상태이나, adb접근 불가일 경우 (대개 재부팅 등으로 인한 타이밍 상 장비 offline)
- 해당 이슈 발생 시 장비가 잠금 상태가 되어 풀리지 않음. 이 문제 역시 해결.

### How should this be tested?
- 라미엘 배포: `BRANCH_WS_SCRCPY=DEV-19630 ./provisioning.py on-premise`
- 안드로이드 폰 연결 --> 세션 연결 성공 확인 --> 연결 해제 --> 물리적 USB 연결 해제 --> nerv에서 is_connected=1 상태로 변경 --> 세션 연결 시도 --> 오류 문구 확인
- sentry에 `Failed: ''` 오류가 남지 않음

### Screenshots (if appropriate)

![image](https://github.com/HardBoiledSmith/ws-scrcpy/assets/12525941/4e72e1a7-7fc9-4a19-94d3-7e3cb62d036a)

