### PR TITLE
DEV-20015 [운영팀:개발팀] Cashwalk : 0155 기기 → 라미엘 앱 나가기 버튼 미동작 확인 요청

### DIFF
--- a/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
+++ b/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
@@ -330,9 +330,14 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
                         device
                             .runShellCommandAdbKit("dumpsys window | grep -E 'mCurrentFocus'")
                             .then((rr) => {
-                                const packageName = rr.split('/')[0].split(' ')[2];
-                                if (packageName !== 'com.sec.android.app.launcher') {
-                                    return device.runShellCommandAdbKit(`am force-stop ${packageName}`);
+                                const mm = rr.match(/mCurrentFocus=Window\{.*\}/);
+                                let pp = mm ? mm[0] : '';
+                                if (!pp) {
+                                    return;
+                                }
+                                pp = pp.split('/')[0].split(' ')[2];
+                                if (pp !== 'com.sec.android.app.launcher') {
+                                    return device.runShellCommandAdbKit(`am force-stop ${pp}`);
                                 }
                                 return;
                             })


### PR DESCRIPTION
### What is this PR for?
- 안드로이드14에서 앱닫기 기능 호환성 해결

### How should this be tested?
- 라미엘 배포
- 기능 테스트: 안드로이드14에서 임의의 앱 실행 --> 앱 닫기 버튼 클릭 --> 앱이 닫히는지 확인
- backward compatitability: 안드로이드 13 이하 버전에서 임의의 앱 실행 --> 앱이 닫히는지 확인
