### PR TITLE
DEV-21859 [라미엘] alert창 뜬 상태에서 heartbeat갱신 안 됨

### DIFF
--- a/src/app/applDevice/client/WdaProxyClient.ts
+++ b/src/app/applDevice/client/WdaProxyClient.ts
@@ -227,6 +227,13 @@ export class WdaProxyClient
             case 'unlock':
                 return this.requestWebDriverAgent(WDAMethod.UNLOCK);
             case 'sendText':
+                const message: Message = {
+                    id: this.getNextId(),
+                    type: ControlCenterCommand.HEARTBEAT,
+                    data: {},
+                };
+                this.sendMessage(message).catch((e) => console.error(e));
+
                 const keys = prompt('텍스트를 입력해 주세요');
                 if (!keys) {
                     return;
@@ -264,6 +271,13 @@ export class WdaProxyClient
                 return this.requestWebDriverAgent(WDAMethod.LOCK);
             }
             case 'reboot': {
+                const message: Message = {
+                    id: this.getNextId(),
+                    type: ControlCenterCommand.HEARTBEAT,
+                    data: {},
+                };
+                this.sendMessage(message).catch((e) => console.error(e));
+
                 const cc = prompt('재부팅하시겠습니까? "확인"을 입력해 주세요');
                 if (cc !== '확인') {
                     return;
@@ -274,6 +288,13 @@ export class WdaProxyClient
             }
             case 'launchApp':
             case 'removeApp': {
+                const message: Message = {
+                    id: this.getNextId(),
+                    type: ControlCenterCommand.HEARTBEAT,
+                    data: {},
+                };
+                this.sendMessage(message).catch((e) => console.error(e));
+
                 const bundleId = prompt('앱키를 입력해주세요.');
                 if (!bundleId) {
                     return;

--- a/src/app/googDevice/toolbox/DroidToolBox2.ts
+++ b/src/app/googDevice/toolbox/DroidToolBox2.ts
@@ -166,6 +166,8 @@ export class DroidToolBox2 {
                         break;
                     }
                     case 'SendText': {
+                        client.sendMessage(CommandControlMessage.createHeartbeatCommand());
+
                         const text = prompt('텍스트를 입력해 주세요');
                         if (!text) {
                             break;
@@ -212,6 +214,8 @@ export class DroidToolBox2 {
                         break;
                     }
                     case 'Reboot': {
+                        client.sendMessage(CommandControlMessage.createHeartbeatCommand());
+
                         const cc = prompt('재부팅하시겠습니까? "확인"을 입력해 주세요');
                         if (cc !== '확인') {
                             break;
@@ -230,6 +234,8 @@ export class DroidToolBox2 {
                         break;
                     }
                     case 'RemoveApp': {
+                        client.sendMessage(CommandControlMessage.createHeartbeatCommand());
+
                         const appKey = prompt('앱키를 입력해 주세요.');
                         if (!appKey) {
                             break;
@@ -238,6 +244,8 @@ export class DroidToolBox2 {
                         break;
                     }
                     case 'LaunchApp': {
+                        client.sendMessage(CommandControlMessage.createHeartbeatCommand());
+
                         const appKey = prompt('앱키를 입력해 주세요.');
                         if (!appKey) {
                             break;


### PR DESCRIPTION
### What is this PR for?
- prompt()로 인해 모든 쓰레드 정지됨 --> heartbeat 타암아웃 발생 --> 해당 이슈 해결

### How should this be tested?
- 아이폰, 안드로이드 sendText, reboot, launch/terminateApp 실행 정상
