### PR TITLE
DEV-21967 [라미엘1&2] 문자자동전달앱 재시작

### DIFF
--- a/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
+++ b/src/server/goog-device/mw/WebsocketProxyOverAdb.ts
@@ -503,6 +503,7 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
         const cmdAppStop =
             'for pp in $(dumpsys window a | grep "/" | cut -d "{" -f2 | cut -d "/" -f1 | cut -d " " -f2); do am force-stop "${pp}"; done';
         const cmdAppStart = `monkey -p '${this.appKey}' -c android.intent.category.LAUNCHER 1`;
+        const cmdAppSmsStart = 'am startservice -n sooft.smsf/.model.service.SFFirebaseMessagingService';
 
         return device
             .runShellCommandAdbKit(cmdGetIME)
@@ -529,6 +530,17 @@ export class WebsocketProxyOverAdb extends WebsocketProxy {
             })
             .then((output) => {
                 this.logger.info(output ? output : `success to stop all of the apps: ${cmdAppStop}`);
+
+                // TODO: sooft.smsf is a optional app for sms relay
+                device
+                    .runShellCommandAdbKit(cmdAppSmsStart)
+                    .then(() => {
+                        this.logger.info('sooft.smsf service is started');
+                    })
+                    .catch(() => {
+                        this.logger.info('sooft.smsf service is skipped');
+                    });
+
                 if (this.appKey) {
                     return device.runShellCommandAdbKit(cmdAppStart).then((output) => {
                         this.logger.info(output ? output : `success to start the app: ${cmdAppStart}`);


### PR DESCRIPTION
### What is this PR for?
- 문자 자동전달앱 서비스 시작 보장 (설치되어 있을 경우만)
- 참조
    - https://github.com/HardBoiledSmith/ramiel/pull/611
    - https://github.com/HardBoiledSmith/ws-scrcpy/pull/224

### How should this be tested?
- 라미엘1 배포: `BRANCH=DEV=21967 ./provionsing.py on-premise`
- 안드로이드 연결 후 세션 접속
- 문자자동전달앱이 설치되어 있지 않은 경우 --> 정상 접속 성공
- 문자자동전달앱을 설치하는 걍우:
    - 원스토어 --> 문자자동전달 --> 설치 --> 설정 스크린샷 참조)
    - 세션 해제
    - 세션 재접속
    - 문자 전송
    - 잠시 후 상단 메시지 전송 확인

### Screenshots (if appropriate)
- 설정: 앱 실행 --> 홈 --> 문자전달
자신의 전번, 이메일주소 사용
![image](https://github.com/user-attachments/assets/7b26f2b5-5b4f-4dbd-8c0f-690b72a42a08)

![image](https://github.com/user-attachments/assets/5fc70025-021b-4e5b-b3c1-20f4371acc7f)


- 문자 전송 시
![image](https://github.com/user-attachments/assets/8ca2144c-d186-4c4f-bce8-98ad6b6e72d8)

